### PR TITLE
Fix for MPI install check

### DIFF
--- a/install_shapepipe
+++ b/install_shapepipe
@@ -9,7 +9,7 @@ LC_CTYPE=en_US.utf8
 #
 ##############################################################################
 
-version="1.2"
+version="1.3"
 
 ##############################################################################
 # EXTERNAL PACKAGE VERSIONS
@@ -257,6 +257,10 @@ exit_code() {
 
 # Function to report package versions
 package_report() {
+  if [ "$CONDA_DEFAULT_ENV" != "shapepipe" ]
+  then
+    activate_shapepipe
+  fi
   INSTALL_SEX=FALSE
   INSTALL_PSFEX=FALSE
   INSTALL_WW=FALSE
@@ -283,17 +287,30 @@ finish() {
   exit_code
 }
 
+check_status () {
+  if [ "$2" == FALSE ]
+  then
+    echo -ne "$1 ${YELLOW}$2${NC}"
+  elif [ "$2" == TRUE ]
+  then
+    echo -ne "$1 ${GREEN}$2${NC}"
+  else
+    echo -ne "$1 ${CYAN}$2${NC}"
+  fi
+  echo -ne " ${CYAN}$3${NC}\n"
+}
+
 # Function to show the installation setup
 setup() {
-  echo 'Operating System:' $SYSOS
-  echo 'Build Conda Environment:' $BUILD_ENV
-  echo 'Install SExtractor:' $INSTALL_SEX
-  echo 'Install PSFEx:' $INSTALL_PSFEX
-  echo 'Install WeightWatcher:' $INSTALL_WW
-  echo 'Install CDSclient:' $INSTALL_CDSCLIENT
-  echo 'Use MPI:' $USE_MPI $MPI_ROOT
-  echo 'ShapePipe Directory:' $PIPE_DIR
-  echo 'Build Directory:' $BUILD_DIR
+  check_status 'Operating System:' $SYSOS
+  check_status 'Build Conda Environment:' $BUILD_ENV
+  check_status 'Install SExtractor:' $INSTALL_SEX
+  check_status 'Install PSFEx:' $INSTALL_PSFEX
+  check_status 'Install WeightWatcher:' $INSTALL_WW
+  check_status 'Install CDSclient:' $INSTALL_CDSCLIENT
+  check_status 'Use MPI:' $USE_MPI $MPI_ROOT
+  check_status 'ShapePipe Directory:' $PIPE_DIR
+  check_status 'Build Directory:' $BUILD_DIR
   echo ''
 }
 
@@ -317,6 +334,19 @@ uninstall() {
   rm -r build dist shapepipe.egg-info .eggs
   source deactivate || conda deactivate
   conda remove -n shapepipe --all -y
+}
+
+# Function to activate ShapePipe environment
+activate_shapepipe() {
+  source activate shapepipe
+  if [ "$?" -eq 0 ]
+  then
+    echo -ne "Activating Conda environment ${CYAN}$CONDA_PREFIX${NC}\n"
+    export LD_LIBRARY_PATH=$CONDA_PREFIX/lib
+  else
+    echo -ne "${RED}ERROR: Could not activate ShapePipe environment.${NC}\n"
+    exit 1
+  fi
 }
 
 ##############################################################################
@@ -513,9 +543,7 @@ then
 fi
 
 # Activate conda environment
-source activate shapepipe
-echo "Activating Conda environment" $CONDA_PREFIX
-export LD_LIBRARY_PATH=$CONDA_PREFIX/lib
+activate_shapepipe
 
 if [ -z "$FFTW_LIB" ]; then FFTW_LIB=$CONDA_PREFIX/lib; fi
 if [ -z "$FFTW_INC" ]; then FFTW_INC=$CONDA_PREFIX/include; fi


### PR DESCRIPTION
For `install_shapepipe`:
- Fixed status report for MPI when `--mpi-root` is provided.
- Fixed issue with `--packages` option when environment is not activated.
- Updated install script version.