### PR TITLE
Ci setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,4 @@ jobs:
         run: |
           conda activate shapepipe
           python setup.py test
+          


### PR DESCRIPTION
- Temporarily disabled GitHub Actions CI tests on macOS due to limited processing quota
- macOS tests will be reactivated once the repository is made public
- resolves #342 