### PR TITLE
Merge memory

### DIFF
--- a/shapepipe/modules/merge_starcat_package/merge_starcat.py
+++ b/shapepipe/modules/merge_starcat_package/merge_starcat.py
@@ -236,7 +236,6 @@ class MergeStarCatMCCD(object):
         for name in self._input_file_list:
             starcat_j = fits.open(name[0], memmap=False)
 
-            print(starcat_j[self._hdu_table].data['VIGNET_LIST'].shape)
             try:
                 stars = np.copy(starcat_j[self._hdu_table].data['VIGNET_LIST'])
             except ValueError:


### PR DESCRIPTION
Added a try/except clause to check the consistency of star FITS catalogue before merging. If FITS file is corrupt for some reason, sometimes the `VIGNET` information is not present. This is now checked.