### PR TITLE
Apidoc build fix

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -20,14 +20,15 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
+          ./install_shapepipe --develop --no-exe --no-mpi
+          conda activate shapepipe
+          python -m pip install --upgrade importlib-metadata
           conda install -c conda-forge pandoc
-          python -m pip install --upgrade pip
-          python -m pip install -r docs/requirements.txt
-          python -m pip install .
 
       - name: Build API documentation
         shell: bash -l {0}
         run: |
+          conda activate shapepipe
           sphinx-apidoc -t docs/_templates -feTMo docs/source shapepipe
           sphinx-build -E docs/source docs/_build
 


### PR DESCRIPTION
## Summary

- closes #514
- change api doc build to shapepipe environment

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [x] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [x] All of the reviewer's comments have been satisfactorily addressed by the developer
