### PR TITLE
Match external docs

### DIFF
--- a/shapepipe/modules/match_external_package/__init__.py
+++ b/shapepipe/modules/match_external_package/__init__.py
@@ -4,17 +4,45 @@ This package contains the module for ``match_external``.
 
 :Author: Martin Kilbinger, Xavier Jimenez
 
-:Parent module:
+:Parent module: ``sextractor_runner``
 
-:Input:
+:Input: SExtractor catalogue
 
-:Output:
+:Output: matched catalogue
 
 Description
 ===========
 
+This module matches an external catalogue to a ShapePipe (SExtractor)
+catalogue. Matching is performed by checking if the 2D angular separation
+between objects is less than a specified tolerance.
+
 Module-specific config file entries
 ===================================
+
+TOLERANCE : float
+    tolerance of matching distance in arcseconds
+COL_MATCH : list
+    internal SExtractor column names to be matched
+HDU : int, optional
+    internal SExtractor catalogue HDU number; default is ``2``
+MODE : str
+    run mode for module, options are ``CLASSIC`` or ``MULTI-EPOCH``
+EXTERNAL_CAT_PATH : str
+    path to the external catalogue
+EXTERNAL_COL_MATCH : list
+    external SExtractor column names to be matched
+EXTERNAL_COL_COPY : list
+    external SExtractor column names to be copied to the matched catalogue
+EXTERNAL_HDU : int, optional
+    external SExtractor catalogue HDU number; default is ``1``
+PREFIX : str, optional
+    output file name prefix; default is ``cat_matched``
+MARK_NON_MATCHED : float, optional
+    if set all objects will be included in the output catalogue and unmatched
+    objects will be marked with the value specified
+OUTPUT_DISTANCE : bool, optional
+    option to output the matching distance; default is ``False``
 
 """
 

--- a/shapepipe/modules/match_external_runner.py
+++ b/shapepipe/modules/match_external_runner.py
@@ -65,13 +65,13 @@ def match_external_runner(
         external_hdu_no = 1
 
     # Output
-    if config.has_option(module_config_sec, 'OUTPUT_FILE_PATTERN'):
-        output_file_pattern = config.get(
+    if config.has_option(module_config_sec, 'PREFIX'):
+        prefix = config.get(
             module_config_sec,
-            'OUTPUT_FILE_PATTERN',
+            'PREFIX',
         )
     else:
-        output_file_pattern = 'cat_matched'
+        prefix = 'cat_matched'
 
     if config.has_option(module_config_sec, 'MARK_NON_MATCHED'):
         mark_non_matched = config.getfloat(
@@ -92,7 +92,7 @@ def match_external_runner(
     # Set output file path
     file_ext = 'fits'
     output_path = (
-        f'{run_dirs["output"]}/{output_file_pattern}{file_number_string}.'
+        f'{run_dirs["output"]}/{prefix}{file_number_string}.'
         + f'{file_ext}'
     )
 


### PR DESCRIPTION
## Summary

- addresses one point in #494 
- added basic documentation for `match_external`

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [x] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [x] All of the reviewer's comments have been satisfactorily addressed by the developer
