### PR TITLE
fixed bug in RunLog class

### DIFF
--- a/shapepipe/pipeline/run_log.py
+++ b/shapepipe/pipeline/run_log.py
@@ -33,7 +33,7 @@ class RunLog(object):
         self._module_list = ','.join(module_list)
         self.current_run = current_run
         self._write()
-        get_list(run_log_file)
+        self._runs = get_list(run_log_file)
 
     def _write(self):
         """Write.


### PR DESCRIPTION
## Summary

Added missing assignment of `RunLog` class variable. Closes #547 

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [x] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [x] All of the reviewer's comments have been satisfactorily addressed by the developer
