### PR TITLE
removed errornous mccd_interp_runner call

### DIFF
--- a/example/cfis/config_tile_Sx_exp_mccd.ini
+++ b/example/cfis/config_tile_Sx_exp_mccd.ini
@@ -21,8 +21,7 @@ RUN_NAME = run_sp_tile_Sx_exp_SxSePsf
 # Module name, single string or comma-separated list of valid module runner names
 MODULE = sextractor_runner, sextractor_runner, setools_runner,
 	 mccd_preprocessing_runner, mccd_fit_val_runner,
-	 merge_starcat_runner, mccd_plots_runner,
-	 mccd_interp_runner
+	 merge_starcat_runner, mccd_plots_runner
 
 # Run mode, SMP or MPI
 MODE = SMP
@@ -284,34 +283,3 @@ PLOT_RHO_STATS = False
 
 # RHO_STATS_STYLE: can be 'HSC' or 'DES'
 RHO_STATS_STYLE = HSC
-
-
-[MCCD_INTERP_RUNNER]
-
-# MODE: Define the way the MCCD interpolation will run.
-#  CLASSIC for classical run.
-#  MULTI-EPOCH for multi epoch.
-MODE = CLASSIC
-
-# Position parameter names
-# for multi-epoch XWIN_WORLD,YWIN_WORLD
-# For classical XWIN_IMAGE,YWIN_IMAGE:
-POSITION_PARAMS = XWIN_IMAGE,YWIN_IMAGE
-
-# Get PSF shapes calculated and saved on the output dict
-GET_SHAPES = True
-
-# Directory with PSF models
-PSF_MODEL_DIR = /Users/tliaudat/Documents/PhD/codes/venv_p3/MCCD_pipeline_integration/test_val_data/fitted_model/
-
-# PSF model patterns
-PSF_MODEL_PATTERN = fitted_model
-
-# PSF model separator
-PSF_MODEL_SEPARATOR = -
-
-# For multi-epoch purposes
-ME_LOG_WCS = $SP_RUN/output/log_exp_headers.sqlite
-
-
-


### PR DESCRIPTION
## Summary

Remove call to mccd_interp_runner during step 8 in `job_sp`, after detection and PSF model on tiles. Probably left from before re-organisation of config file.

This call uses default input file patterns and results in an error. I don't think this call is useful here.

Closes #567 

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [ ] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [ ] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [x] All of the reviewer's comments have been satisfactorily addressed by the developer
