### PR TITLE
merge setools star catalogues

### DIFF
--- a/docs/source/post_processing.md
+++ b/docs/source/post_processing.md
@@ -83,7 +83,7 @@ At this step all required `ShapePipe` resulting output files are available in th
    A. Analyse psf validation files
    
       ```bash
-      psf_residuals -p PSF
+      prepare_star_cat -p PSF
       ```
       with options as for `post_proc_sp`.
       This script identifies all psf validation files (from all processed tiles downloaded to `pwd`), creates symbolic links,

--- a/docs/source/random_cat.md
+++ b/docs/source/random_cat.md
@@ -1,9 +1,14 @@
-# Create random catalogue
+# Create random catalogues and masks
 
-This section describes how to create a random catalogue from ShapePipe
-mask files corresponding to a selection of tiles.
+This section describes how to create tile-based random catalogues and healpix
+masks, and combined randoms and masks for a selection of tiles.
+
+The masked regions are obtained on input from ShapePipe pixel mask ("pipeline flag")
+files.
 
 ## Set up
+
+### ID file and shell variables
 
 First, if if does not exist already, create the file ``tile_numbers.txt`` containing a list of tile IDs,
 one per line. This is the same format as the input file to ``get_images_runner``.
@@ -17,7 +22,7 @@ export SP_RUN=.
 export SP_CONFIG=/path/to/config-files
 ```
 
-## Get images or image headers
+### Get images or image headers
 
 We need to footprint of the image tiles. If they have been downloaded for a ``ShapePipe`` run,
 check that they are accessible as last run of the ``get_images_runner`` module.
@@ -27,9 +32,9 @@ If not, we can just download the headers to gain significant download time.
 shapepipe_run -c $SP_CONFIG/config_get_tiles_vos_headers.ini
 ```
 
-## Check mask files
+### Check pixel mask files
 
-Make sure that all mask files are present. If they have been downloaded from ``vos`` as ``.tgz`` files,
+Make sure that all pixel mask files are present. If they have been downloaded from ``vos`` as ``.tgz`` files,
 type
 ```bash
 canfar_avail_results -i tile_numbers.txt --input_path . -v -m -o missing_mask.txt
@@ -56,7 +61,7 @@ Untar .tgz files if required,
 while read p; do tar xvf pipeline_flag_$p.tgz; done <missing_mask.txt
 ```
 
-## Prepare combined mask input directory
+### Prepare combined mask input directory
 
 To combine all mask files into one input directory, easy to find by the subsequent ``ShapePipe`` module
 ``random_runner``, type
@@ -68,25 +73,47 @@ To make sure everything went well, check the linked .fits files with
 canfar_avail_results -i tile_numbers.txt --input_path output/run_sp_combined_flag/mask_runner/output -x fits -v -m
 ```
 
-## Create random catalogue
+## Create random catalogue and helapix mask per tile
 
-First, create a random catalogue for each input tile and mask file,
+Run
 ```bash
 shapepipe_run -c $SP_CONFIG/config_Rc.ini
 ```
-Next, merge those catalogues into a numpy binary (``.npy``) file,
+The random catalogue and, with the config entry `SAVE_MASK_AS_HEALPIX = True``
+a healpix mask FITS file, will be written to disk.
+
+## Create joint random catalogue
+
+The individual tile-based random catalogues can be merged into a numpy
+binary (``.npy``) file with
 ```bash
 merge_final_cat -i output/run_sp_Rc/random_cat_runner/output -n random_cat -v
 ```
 
-## Results
+### Results
 
 We can plot the random objects,
 ```bash
 python ~/astro/repositories/github/sp_validation/scripts/plot_rand.py
 ```
-and finally compute the effective survey area,
+and also compute the effective survey area,
 ```bash
 ~/astro/repositories/github/sp_validation/scripts/compute_area.py
 ```
+
+## Create joint healpix mask
+
+First, for convenience all image headers with WCS information are
+linked from within one directory, with
+```bash
+prepare_tiles_for_final -i
+```
+
+Next, read all tile mask and WCS information, and create a joint full-sky
+healpix mask with
+```bash
+/path/to/sp_validation/scripts/scripts/combine_hp_masks.py -p -v
+```
+With the option ``-p`` the mask is plotted in Mollweid projection.
+
 

--- a/example/cfis/config_MsPl_stars.ini
+++ b/example/cfis/config_MsPl_stars.ini
@@ -1,0 +1,101 @@
+# ShapePipe configuration file for post-processing.
+# merge star cat and diagnostics plots for all setools-selected stars.
+
+
+## Default ShapePipe options
+[DEFAULT]
+
+# verbose mode (optional), default: True, print messages on terminal
+VERBOSE = True
+
+# Name of run (optional) default: shapepipe_run
+RUN_NAME = run_sp_MsPl_stars_all
+
+# Add date and time to RUN_NAME, optional, default: False
+RUN_DATETIME = False
+
+
+## ShapePipe execution options
+[EXECUTION]
+
+# Module name, single string or comma-separated list of valid module runner names
+MODULE = merge_starcat_runner, mccd_plots_runner
+
+# Parallel processing mode, SMP or MPI
+MODE = SMP
+
+
+## ShapePipe file handling options
+[FILE]
+
+# Log file master name, optional, default: shapepipe
+LOG_NAME = log_sp
+
+# Runner log file name, optional, default: shapepipe_runs
+RUN_LOG_NAME = log_run_sp
+
+# Input directory, containing input files, single string or list of names
+INPUT_DIR = $SP_RUN/star_all_ind
+
+# Output directory
+OUTPUT_DIR = $SP_RUN/output
+
+
+## ShapePipe job handling options
+[JOB]
+
+# Batch size of parallel processing (optional), default is 1, i.e. run all jobs in serial
+SMP_BATCH_SIZE = 4
+
+# Timeout value (optional), default is None, i.e. no timeout limit applied
+TIMEOUT = 96:00:00
+
+
+## Module options
+[MERGE_STARCAT_RUNNER]
+
+INPUT_DIR = star_all_ind
+
+PSF_MODEL = setools
+
+NUMBERING_SCHEME = -0000000-0
+
+# Input file pattern(s), list of strings with length matching number of expected input file types
+# Cannot contain wild cards
+FILE_PATTERN = star_selection
+
+# FILE_EXT (optional) list of string extensions to identify input files
+FILE_EXT = .fits
+
+
+[MCCD_PLOTS_RUNNER]
+
+# NUMBERING_SCHEME (optional) string with numbering pattern for input files
+NUMBERING_SCHEME = -0000000
+
+FILE_PATTERN = full_starcat
+FILE_EXT = .fits
+
+PLOT_MEANSHAPES = True
+X_GRID = 5
+Y_GRID = 10
+
+# Optional: max values for elliptity and residual ellipticities
+MAX_E = 0.05
+MAX_DE = 0.005
+
+PSF = psfex
+PLOT_HISTOGRAMS = True
+REMOVE_OUTLIERS = False
+
+# X_GRID, Y_GRID: correspond to the number of bins in each direction of each
+# CCD from the focal plane. Ex: each CCD will be binned in 5x10 regular grids.
+#
+# REMOVE_OUTLIERS: Remove validated stars that are outliers in terms of shape
+# before drawing the plots.
+
+PLOT_RHO_STATS = True
+RHO_STATS_STYLE = HSC
+
+RHO_STATS_YLIM_L = 1e-10, 4e-5
+RHO_STATS_YLIM_R = 1e-8, 4e-5

--- a/scripts/python/merge_final_cat.py
+++ b/scripts/python/merge_final_cat.py
@@ -4,12 +4,11 @@
 
 """Script merge_final_cat.py
 
-Merge all final catalogues, created by ShapePipe module 'make_catalogue_runner',
-into a joined numpy binary file.
+Merge all final catalogues, created by ShapePipe module
+``make_catalogue_runner``, into a joined numpy binary file.
 
 :Authors: Axel Guinot, Martin Kilbinger
 
-:Date: 2020
 """
 
 from astropy.io import fits
@@ -41,11 +40,9 @@ class param:
 
 
 def params_default():
-    """Set default parameter values.
-
-    Parameters
-    ----------
-    None
+    """Params Default.
+    
+    Set default parameter values.
 
     Returns
     -------
@@ -63,7 +60,9 @@ def params_default():
 
 
 def parse_options(p_def):
-    """Parse command line options.
+    """Parse Options.
+    
+    Parse command line options.
 
     Parameters
     ----------
@@ -139,7 +138,9 @@ def parse_options(p_def):
 
 
 def check_options(options):
-    """Check command line options.
+    """Check Options.
+    
+    Check command line options.
 
     Parameters
     ----------
@@ -156,7 +157,9 @@ def check_options(options):
 
 
 def update_param(p_def, options):
-    """Return default parameter, updated and complemented according to options.
+    """Update Param.
+    
+    Return default parameter, updated and complemented according to options.
 
     Parameters
     ----------
@@ -189,7 +192,9 @@ def update_param(p_def, options):
 
 
 def read_param_file(path, verbose=False):
-    """Return parameter list read from file
+    """Read Param File.
+    
+    Return parameter list read from file.
 
     Parameters
     ----------
@@ -242,7 +247,9 @@ def read_param_file(path, verbose=False):
                             
 
 def get_data(path, hdu_num, param_list):
-    """Return data of selected columns from FITS file.
+    """Get Data.
+    
+    Return data of selected columns from FITS file.
 
     Parameters
     ----------
@@ -308,7 +315,8 @@ def main(argv=None):
 
         add_this_l = False
 
-        # mark to add if correct extension, matches input pattern, not `.npy` file
+        # mark to add if correct extension, matches input pattern,
+        not `.npy` file
         if (
             this_l.endswith(ext)
             and (f'{param.input_name_base}' in this_l)
@@ -355,7 +363,10 @@ def main(argv=None):
 
             d = np.concatenate((d, dd))
         except:
-            print(f'Error while adding file \'{fname}\', {len(dd)} objects not in final cat')
+            print(
+                f'Error while adding file \'{fname}\', {len(dd)} objects'
+                ' not in final cat'
+            )
 
     # Save merged catalogue as numpy binary file
     if param.verbose:

--- a/scripts/sh/post_proc_sp.bash
+++ b/scripts/sh/post_proc_sp.bash
@@ -70,7 +70,7 @@ SP_CONFIG=$SP_BASE/example/cfis
 # PSF
 
 ## Collect all psfinterp results 
-psf_residuals -p $psf
+prepare_star_cat -p $psf
 
 ## Merge all psfinterp results and compute PSF residuals
 shapepipe_run -c $SP_CONFIG/config_MsPl_$psf.ini 

--- a/scripts/sh/prepare_star_cat.bash
+++ b/scripts/sh/prepare_star_cat.bash
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# Name: psf_residuals.bash
-# Description: Compute and plot PSF residuals from
-#	       results processed on canfar
+# Name: prepare_star_cat.bash
+# Description: Create directory and links to all PSF or star catalogue files
+#              from previous ShapePipe runs.
 # Author: Martin Kilbinger <martin.kilbinger@cea.fr>
-# Date: 05/2020
+
 
 # Command line arguments
 
@@ -16,7 +16,7 @@ usage="Usage: $(basename "$0") [OPTIONS]
 \n\nOptions:\n
    -h\tthis message\n
    -p, --psf MODEL\n
-    \tPSF model, one in ['psfex'|'mccd'], default='$psf'\n
+    \tPSF model, one in ['psfex'|'mccd'|'setools'], default='$psf'\n
 "
 
 ## Parse command line
@@ -39,41 +39,16 @@ while [ $# -gt 0 ]; do
 done
 
 
-## Default variables
-psfval_file_base="validation_psf"
-dir_individual="psf_validation_ind"
+## Path variables
+if [ "$psf" == "psfex" ] || [ "$psf" == "mccd" ]; then
+  psfval_file_base="validation_psf"
+  dir_individual="psf_validation_ind"
+else
+  psfval_file_base="mask/star_selection"
+  dir_individual="star_all_ind"
+fi
+
 pwd=`pwd`
-
-# Command line sarguments
-
-## Help string
-usage="Usage: $(basename "$0") [OPTIONS]
-\n\nOptions:\n
-   -h\tthis message\n
-   -p, --psf MODEL\n
-    \tPSF model, one in ['psfex'|'mccd'], default='$psf'\n
-"
-
-## Parse command line
-TILE_ARR=()
-while [ $# -gt 0 ]; do
-  case "$1" in
-    -h)
-      echo -ne $usage
-      exit 0
-      ;;
-    -p|--psf)
-      psf="$2"
-      shift
-      ;;
-    *)
-      echo "Invalid command line argument '$2'"
-      echo -ne $usage
-      exit 1
-      ;;
-  esac
-  shift
-done
 
 
 ## Functions
@@ -99,8 +74,10 @@ fi
 
 if [ "$psf" == "psfex" ]; then
   runner="psfex_interp_runner"
-else
+elif [ "$psf" == "mccd" ]; then
   runner="mccd_fit_val_runner"
+else
+  runner="setools_runner"
 fi
 
 # Find all psf validation files and create links.

--- a/scripts/sh/prepare_tiles_for_final.bash
+++ b/scripts/sh/prepare_tiles_for_final.bash
@@ -17,7 +17,7 @@ usage="Usage: $(basename "$0") [OPTIONS]
 \n\nOptions:\n
    -h\tthis message\n
    -c, --cat TYPE\n
-    \tCatalogue type, one in ['final'|'flag'], default='$cat'\n
+    \tCatalogue type, one in ['final'|'flag'|'image'], default='$cat'\n
 "
 
 ## Parse command line
@@ -54,8 +54,8 @@ function link_s () {
 }
 
 ## Check options
-if [ "$cat" != "final" ] && [ "$cat" != "flag" ]; then
-  echo "cat (option -c) needs to be 'final' or 'flag'"
+if [ "$cat" != "final" ] && [ "$cat" != "flag" ] && [ "$cat" != "image" ]; then
+  echo "cat (option -c) needs to be 'final', 'flag', or 'image'"
   exit 2
 fi
 
@@ -68,9 +68,12 @@ out_base="output"
 if [ "$cat" == "final" ]; then
   run_dir="run_sp_combined"
   INPUT="$pwd/$out_base/run_sp_Mc_*"
-else
+elif [ "$cat" == "flag" ]; then
   run_dir="run_sp_combined_flag"
   INPUT="$pwd/$out_base/run_sp_tile_Ma_*"
+else
+  run_dir="run_sp_combined_image"
+  INPUT="$pwd/$out_base/run_sp_Git_*"
 fi
 
 log_path="$pwd/$out_base/log_run_sp.txt"
@@ -85,12 +88,19 @@ if [ "$cat" == "final" ]; then
   PATTERNS=(
 	  "final_cat-*"
   )
-else
+elif [ "$cat" == "flag" ]; then
   DIRS=(
 	  "mask_runner"
   )
   PATTERNS=(
 	  "pipeline_flag-*"
+  )
+else
+  DIRS=(
+    "get_images_runner"
+  )
+  PATTERNS=(
+	  "CFIS_image-*"
   )
 fi
 

--- a/shapepipe/modules/merge_starcat_package/merge_starcat.py
+++ b/shapepipe/modules/merge_starcat_package/merge_starcat.py
@@ -629,6 +629,83 @@ class MergeStarCatSetools(object):
         self._w_log = w_log
         self._hdu_table = hdu_table
 
+    @classmethod
+    def get_moments(cls, data):
+        """Get Moments
+
+        Return second-order moments.
+
+        Parameters
+        ----------
+        data : dict
+            input data
+
+        Returns
+        -------
+        m11 : float
+            second-order moment along xy
+        m20 : float
+            second-order moment along x
+        m02 : float
+            second-order moment along y
+
+        """
+        # SExtractor output. First and second moments are normalised.
+        # Second moments are centred.
+        q11 = 'X2WIN_IMAGE'
+        q22 = 'Y2WIN_IMAGE'
+        q12 = 'XYWIN_IMAGE'
+
+        # Second moments
+        m11 = data[q12]
+        m20 = data[q11]
+        m02 = data[q22]
+
+        return m11, m20, m02
+
+    @classmethod
+    def get_ellipticity(cls, m11, m20, m02, typ):
+        """Get Ellipticity
+
+        Compute ellipticity from second-order moments.
+
+        Parameters
+        ----------
+        m11 : float
+            second-order moment along xy
+        m20 : float
+            second-order moment along x
+        m02 : float
+            second-order moment along y
+        typ : str
+            ellipticity type, allowed are 'epsilon', 'chi'
+
+        Returns
+        -------
+        list
+            ellipticity components
+        
+        """
+        if typ == 'epsilon':                                                       
+            # Determinant = (Q_11 Q_22 - Q_12^2)^(1/2)                              
+            det = np.sqrt(m20 * m02 - m11 * m11)                
+        elif typ == 'chi':                                                         
+            det = 0                                                                 
+        else:                                                                       
+            raise ValueError(f'Invalid ellipticity type {type}')
+                                                                                
+        # Denominator = Q_11 + Q_22 [ + 2 * det]                                    
+        den = m20 + m02 + 2 * det                                         
+                                                                                
+        # Ellipticity = (Q_11 - Q_22 + 2 i Q_12) / den                              
+        ell = (m20 - m02 + 1j * 2 * m11) / den                       
+                                                                                
+        if type == 'chi':                                                           
+            # chi estimates 2*g, so to get g we have to divide by 2                 
+            ell = ell / 2                                                           
+                                                                                
+        return ell.real, ell.imag
+
     def process(self):
         """Process.
 
@@ -636,9 +713,9 @@ class MergeStarCatSetools(object):
 
         """
         x, y, ra, dec = [], [], [], []
-        g1, g2, size = [], [], []
-        flag_star = [], []
-        mag, snr, psfex_acc = [], [], []
+        eps1, ep2, chi1, chi2, size = [], [], [], [], []
+        flags, flags_ext = [], []
+        mag, snr = [], []
         ccd_nb = []
 
         self._w_log.info(
@@ -652,17 +729,19 @@ class MergeStarCatSetools(object):
 
             # positions
             x += list(data_j['XWIN_IMAGE'])
-            y += list(data_j['XWIN_IMAGE'])
+            y += list(data_j['YWIN_IMAGE'])
             ra += list(data_j['XWIN_WORLD'])
             dec += list(data_j['YWIN_WORLD'])
 
-            # shapes (convert sigmas to R^2)
-            #g1 += list(data_j['E1_STAR_HSM'])
-            #g2 += list(data_j['E2_STAR_HSM'])
-            #size += list(data_j['SIGMA_STAR_HSM']**2)
+            m11, m20, m02 = self.get_moments(data_j)
+            eps1, eps2 = self.get_ellipticity(m11, m20, m02, 'epsilon')
+            chi1, chi2 = self.get_ellipticity(m11, m20, m02, 'chi')
+
+            size += list(data_j['FLUX_RADIUS'])
 
             # flags
-            flag_star += list(data_j['FLAGS_WIN'])
+            flags += list(data_j['FLAGS_WIN'])
+            flags_ext += list(data_j['IMAFLAGS_ISO'])
 
             # misc
             mag += list(data_j['MAG_WIN'])
@@ -671,7 +750,7 @@ class MergeStarCatSetools(object):
             # CCD number
             ccd_nb += [
                 re.split(r"\-([0-9]*)\-([0-9]+)\.", name[0])[-2]
-            ] * len(data_j['RA'])
+            ] * len(data_j['XWIN_IMAGE'])
 
         # Prepare output FITS catalogue
         output = file_io.FITSCatalogue(
@@ -687,14 +766,16 @@ class MergeStarCatSetools(object):
             'Y': y,
             'RA': ra,
             'DEC': dec,
-            'E1_STAR_HSM': g1,
-            'E2_STAR_HSM': g2,
-            'SIGMA_STAR_HSM': np.sqrt(size),
-            'FLAG_STAR_HSM': flag_star,
+            'EPS1': eps1,
+            'EPS2': eps2,
+            'CHI1': chi1,
+            'CHI2': chi2,
+            'SIZE': size,
+            'FLAGS': flags,
+            'FLAGS_EXT': flags_ext,
             'MAG': mag,
             'SNR': snr,
-            'ACCEPTED': psfex_acc,
-            'CCD_NB': ccd_nb
+            'CCD_NB': ccd_nb,
         }
 
         # Write file

--- a/shapepipe/modules/merge_starcat_runner.py
+++ b/shapepipe/modules/merge_starcat_runner.py
@@ -30,7 +30,7 @@ def merge_starcat_runner(
     """Define The Merge Star Catalogues Runner."""
     # Read config file options
     psf_model = config.get(module_config_sec, 'PSF_MODEL')
-    allowed_psf_models = ('psfex', 'mccd')
+    allowed_psf_models = ('psfex', 'mccd', 'setools')
     if psf_model not in allowed_psf_models:
         raise ValueError(
             f'Invalid config entry PSF_MODEL={psf_model} found, '
@@ -43,8 +43,10 @@ def merge_starcat_runner(
     # Set merge class to use
     if psf_model == 'mccd':
         MSC = merge_starcat.MergeStarCatMCCD
-    else:
+    elif psf_model == 'psfex':
         MSC = merge_starcat.MergeStarCatPSFEX
+    elif psf_model == 'setools':
+        MSC = merge_starcat.MergeStarCatSetools
 
     # Create instance of merge class
     merge_inst = MSC(input_file_list, output_dir, w_log)

--- a/shapepipe/utilities/cfis.py
+++ b/shapepipe/utilities/cfis.py
@@ -6,11 +6,9 @@ CFIS module.
 
 """
 
-import errno
 import glob
 import os
 import re
-import shlex
 import sys
 
 import astropy.coordinates as coords


### PR DESCRIPTION
## Summary

Modifications required to merge setools output (SExtractor) catalogue of selected stars.


> Developers should provide a summary of the proposed changes here and include "closes #<ISSUE NUMBER>" if this addresses an open issue.

Main changes:
- read FITS columns different from `mccd` or `psfex` catalogues.
- compute ellipticity from SExtractor moments (probably not accurate. but could still be useful).

Closes #583 

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [ ] The PR targets the `develop` branch
- [ ] The PR is assigned to the developer
- [ ] The PR has appropriate labels
- [ ] The PR is included in appropriate projects and/or milestones
- [ ] The PR includes a clear description of the proposed changes
- [ ] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [ ] The code and documentation style match the current standards
- [ ] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [ ] API docs have been built and checked at least once (if relevant)
- [ ] All changed files have been checked and comments provided to the developer
- [ ] All of the reviewer's comments have been satisfactorily addressed by the developer
