### PR TITLE
Added COLNUM variable to exposure finder runner

### DIFF
--- a/shapepipe/modules/find_exposures_package/__init__.py
+++ b/shapepipe/modules/find_exposures_package/__init__.py
@@ -25,7 +25,9 @@ identification (``HISTORY``), and the exposure file patterns.
 Module-specific config file entries
 ===================================
 
-None
+COLNUM : int
+   Column number to find exposure in fits header of tile image for the HISTORY
+   string
 """
 
 __all__ = ['find_exposures.py']

--- a/shapepipe/modules/find_exposures_package/find_exposures.py
+++ b/shapepipe/modules/find_exposures_package/find_exposures.py
@@ -28,11 +28,12 @@ class FindExposures():
 
     """
 
-    def __init__(self, img_tile_path, output_path, w_log):
+    def __init__(self, img_tile_path, output_path, w_log, colnum):
 
         self._img_tile_path = img_tile_path
         self._output_path = output_path
         self._w_log = w_log
+        self._colnum = colnum
 
     def process(self):
         """Process.
@@ -83,10 +84,11 @@ class FindExposures():
             temp = _hist.split(' ')
 
             pattern = r'(.*)\.{1}.*'
-            pattern_match = re.search(pattern, temp[3])
+            pattern_match = re.search(pattern, temp[self._colnum])
             if not pattern_match:
                 raise IndexError(
-                    f're match \'{pattern}\' failed for filename \'{temp[3]}\''
+                    f're match \'{pattern}\' failed for filename'
+                    + f' \'{temp[self._colnum]}\''
                 )
 
             exp_name = pattern_match.group(1)

--- a/shapepipe/modules/find_exposures_runner.py
+++ b/shapepipe/modules/find_exposures_runner.py
@@ -32,11 +32,15 @@ def find_exposures_runner(
     # Create output ascii file name
     output_path = f'{run_dirs["output"]}/exp_numbers{file_number_string}.txt'
 
+    # Give clumn number for exposure name in fits header
+    colnum = config.getint(module_config_sec, 'COLNUM')
+
     # Create find exposures class instance
     find_exp_inst = find_exposures.FindExposures(
         input_file_name,
         output_path,
-        w_log
+        w_log,
+        colnum,
     )
 
     # Run processing


### PR DESCRIPTION
## Summary

Added a variable COLNUM to indicate where to find the exposure name in the tile history key
This was hardcoded and caused a bug on Axel's simulations. 

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [x] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [x] All of the reviewer's comments have been satisfactorily addressed by the developer
