### PR TITLE
Docker image

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,41 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM continuumio/miniconda3
+
+LABEL Description="ShapePipe Docker Image"
+WORKDIR /home
+ENV SHELL /bin/bash
+
+ARG CC=gcc-9
+ARG CXX=g++-9
+
+RUN apt-get update --allow-releaseinfo-change && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install gcc-9 g++-9 -y && \
+    apt-get install locales -y && \
+    apt install libgl1-mesa-glx -y && \
+    apt-get clean
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+COPY . /home
+
+RUN ./install_shapepipe --develop --vos

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG CXX=g++-9
 RUN apt-get update --allow-releaseinfo-change && \
     apt-get update && \
     apt-get upgrade -y && \
+    apt-get install make -y && \
     apt-get install gcc-9 g++-9 -y && \
     apt-get install locales -y && \
     apt install libgl1-mesa-glx -y && \


### PR DESCRIPTION
## Summary

closes #598 

- Added a `Dockerfile` for building Docker images with ShapePipe pre-installed
- Added GitHub action for automatically building the Docker image when changes are merged to `master`

If you want to test things locally you can checkout this branch and do the following.

```bash
docker build -t shapepipe .
```

> Note: This will take a while. If you are on an M1 Mac then add the argument `--platform linux/amd64` after `build`.

Then you can launch a container.

```bash
docker run -it --rm shapepipe
```

You will find all of the ShapePipe files in `/home`. The `shapepipe` environment will already be available with all the dependencies installed.

## To Do

- [ ] Update Dockerfile with CANFAR-specific dependencies 
- [ ] Update GitHub action to also push the built image to the CANFAR container registry

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [x] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [ ] All of the reviewer's comments have been satisfactorily addressed by the developer
