### PR TITLE
Fixed candide qsub example config file

### DIFF
--- a/example/pbs/config_smp.ini
+++ b/example/pbs/config_smp.ini
@@ -2,7 +2,7 @@
 
 ## ShapePipe execution options
 [EXECUTION]
-MODULE = python_example, serial_example, execute_example
+MODULE = python_example_runner, serial_example_runner, execute_example_runner
 MODE = smp
 
 ## ShapePipe file handling options
@@ -16,8 +16,8 @@ SMP_BATCH_SIZE = 4
 TIMEOUT = 00:01:35
 
 ## Module options
-[PYTHON_EXAMPLE]
+[PYTHON_EXAMPLE_RUNNER]
 MESSAGE = The obtained value is:
 
-[SERIAL_EXAMPLE]
+[SERIAL_EXAMPLE_RUNNER]
 ADD_INPUT_DIR = $SPDIR/example/data/numbers, $SPDIR/example/data/letters


### PR DESCRIPTION
## Summary

Fixed bug in the PBS (qsub) example config file for candide.

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [ ] The PR targets the `develop` branch
- [ ] The PR is assigned to the developer
- [ ] The PR has appropriate labels
- [ ] The PR is included in appropriate projects and/or milestones
- [ ] The PR includes a clear description of the proposed changes
- [ ] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [ ] The code and documentation style match the current standards
- [ ] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [ ] API docs have been built and checked at least once (if relevant)
- [ ] All changed files have been checked and comments provided to the developer
- [ ] All of the reviewer's comments have been satisfactorily addressed by the developer
