### PR TITLE
mccd runner: DEC -> DES for rho stats mode

### DIFF
--- a/shapepipe/modules/mccd_plots_runner.py
+++ b/shapepipe/modules/mccd_plots_runner.py
@@ -129,9 +129,9 @@ def mccd_plots_runner(
             )
             warnings.warn(msg)
             w_log.info(msg)
-        elif rho_stat_plot_style != 'HSC' and rho_stat_plot_style != 'DEC':
+        elif rho_stat_plot_style != 'HSC' and rho_stat_plot_style != 'DES':
             msg = (
-                'The rho stat definition should be HSC or DEC. An unknown'
+                'The rho stat definition should be HSC or DES. An unknown'
                 + ' definition was used. Rho stat calculation aborted.'
             )
             warnings.warn(msg)


### PR DESCRIPTION
## Summary

Typo in mccd runner, keyword for rho stats mode should be `DES` and not `DEC`.

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [x] All of the reviewer's comments have been satisfactorily addressed by the developer
