### PR TITLE
N epoch test

### DIFF
--- a/shapepipe/modules/mccd_package/mccd_interpolation_script.py
+++ b/shapepipe/modules/mccd_package/mccd_interpolation_script.py
@@ -397,8 +397,9 @@ class MCCDinterpolator(object):
         key_ne = 'N_EPOCH'
         if key_ne not in cat.get_data():
             raise KeyError(
-                f'Key {key_ne} not found; run previous module (SExtractor)'
-                + ' in multi-epoch mode'
+                f'Key {key_ne} not found in input galaxy catalogue, needed for'
+                + ' PSF interpolation to multi-epoch data; run previous module'
+                + ' (SExtractor) in multi-epoch mode'
             )
         n_epoch = np.copy(cat.get_data()[key_ne])
 

--- a/shapepipe/modules/mccd_package/mccd_interpolation_script.py
+++ b/shapepipe/modules/mccd_package/mccd_interpolation_script.py
@@ -378,6 +378,11 @@ class MCCDinterpolator(object):
 
         Interpolate PSFs for multi-epoch run.
 
+        Raises
+        ------
+        KeyError
+            If 'N_EPOCH' key not in input catalogue
+
         Returns
         -------
         output_dict: dict
@@ -389,7 +394,13 @@ class MCCDinterpolator(object):
         cat.open()
 
         all_id = np.copy(cat.get_data()['NUMBER'])
-        n_epoch = np.copy(cat.get_data()['N_EPOCH'])
+        key_ne = 'N_EPOCH'
+        if key_ne not in cat.get_data():
+            raise KeyError(
+                f'Key {key_ne} not found; run previous module (SExtractor)'
+                + ' in multi-epoch mode'
+            )
+        n_epoch = np.copy(cat.get_data()[key_ne])
 
         list_ext_name = cat.get_ext_name()
         hdu_ind = [i for i in range(len(list_ext_name)) if

--- a/shapepipe/modules/psfex_interp_package/psfex_interp.py
+++ b/shapepipe/modules/psfex_interp_package/psfex_interp.py
@@ -570,8 +570,9 @@ class PSFExInterpolator(object):
         key_ne = 'N_EPOCH'
         if key_ne not in cat.get_data():
             raise KeyError(
-                f'Key {key_ne} not found; run previous module (SExtractor)'
-                + ' in multi-epoch mode'
+                f'Key {key_ne} not found in input galaxy catalogue, needed for'
+                + ' PSF interpolation to multi-epoch data; run previous module'
+                + ' (SExtractor) in multi-epoch mode'
             )
         n_epoch = np.copy(cat.get_data()[key_me])
 

--- a/shapepipe/modules/psfex_interp_package/psfex_interp.py
+++ b/shapepipe/modules/psfex_interp_package/psfex_interp.py
@@ -551,6 +551,11 @@ class PSFExInterpolator(object):
 
         Interpolate PSFs for multi-epoch run.
 
+        Raises
+        ------
+        KeyError
+            If 'N_EPOCH' key not in input catalogue
+
         Returns
         -------
         dict
@@ -562,7 +567,13 @@ class PSFExInterpolator(object):
         cat.open()
 
         all_id = np.copy(cat.get_data()['NUMBER'])
-        n_epoch = np.copy(cat.get_data()['N_EPOCH'])
+        key_ne = 'N_EPOCH'
+        if key_ne not in cat.get_data():
+            raise KeyError(
+                f'Key {key_ne} not found; run previous module (SExtractor)'
+                + ' in multi-epoch mode'
+            )
+        n_epoch = np.copy(cat.get_data()[key_me])
 
         list_ext_name = cat.get_ext_name()
         hdu_ind = [


### PR DESCRIPTION
## Summary

In the PSFEx and MCCD interpolation modules, a check is added for the input key 'N_EPOCH'. A KeyError is raised if not present. Closes #626 .

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [ ] All of the reviewer's comments have been satisfactorily addressed by the developer
