### PR TITLE
Corrected documentation: module names in module sections

### DIFF
--- a/shapepipe/modules/mccd_interp_runner.py
+++ b/shapepipe/modules/mccd_interp_runner.py
@@ -53,7 +53,6 @@ def mccd_interp_runner(
             module_config_sec,
             'PSF_MODEL_SEPARATOR'
         )
-        # psfcat_path, galcat_path = input_file_list
         galcat_path = input_file_list[0]
 
         # verify that the MCCD model exists

--- a/shapepipe/modules/mccd_package/__init__.py
+++ b/shapepipe/modules/mccd_package/__init__.py
@@ -123,7 +123,8 @@ POSITION_PARAMS: (list) str
 GET_SHAPES: bool
     Calculate PSF model shapes and save to output if ``True``
 PSF_MODEL_DIR: str
-    Input directories for the fitted MCCD PSF model files
+    Module name of last run producing the fitted MCCD PSF model files.
+    The specifier "last:" is not required
 PSF_MODEL_PATTERN: str
     Pattern of the fitted PSF models
 PSF_MODEL_SEPARATOR: str

--- a/shapepipe/modules/psfex_interp_package/__init__.py
+++ b/shapepipe/modules/psfex_interp_package/__init__.py
@@ -32,10 +32,11 @@ STAR_THRESH : int
     Threshold of stars under which the PSF is not interpolated
 CHI2_THRESH : int
     Threshold for chi squared (:math:`\chi^2`)
-ME_DOT_PSF_DIR : list
-    Input directories for PSFEx PSF model files, for multi-epoch processing
-ME_DOT_PSF_PATTERN : list
-    Input file name patterns for PSFEx PSF model files, for multi-epoch
+ME_DOT_PSF_DIR : str
+    Module name of last run producing PSFEx PSF model files, for multi-epoch
+    processing. The specifier "last:" is not required
+ME_DOT_PSF_PATTERN : str
+    Input file name pattern for PSFEx PSF model files, for multi-epoch
     processing
 ME_LOG_WCS : str
     Path to world coordinate system log file (``*sqlite``)

--- a/shapepipe/modules/vignetmaker_package/__init__.py
+++ b/shapepipe/modules/vignetmaker_package/__init__.py
@@ -36,8 +36,9 @@ MODE : str
 PREFIX : str or list
     Output file name prefix(es)
 ME_IMAGE_DIR : list
-    Input directories for single-exposure flags, images, weights, and
-    SExtractor background images, for multi-epoch processing
+    Module names of last run producing single-exposure flags, images, weights,
+    and SExtractor background images, for multi-epoch processing. The specifier
+    "last:" is not required
 ME_IMAGE_PATTERN : list
     Input file name patterns for flag, image, weight, and SExtractor background
     files, for multi-epoch processing


### PR DESCRIPTION
## Summary

In some module sections (psf interpolation, vignet makes), the module names of last runs are read.
The documentation erroneously states these as "input directories". This is being corrected with this PR.

Closes #629


## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [ ] The code and documentation style match the current standards
- [ ] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [ ] API docs have been built and checked at least once (if relevant)
- [ ] All changed files have been checked and comments provided to the developer
- [ ] All of the reviewer's comments have been satisfactorily addressed by the developer
