### PR TITLE
Rho statistics: Flexible use of either training or test star sample

### DIFF
--- a/example/cfis/config_MsPl_mccd.ini
+++ b/example/cfis/config_MsPl_mccd.ini
@@ -1,6 +1,5 @@
-# ShapePipe configuration file for post-processing
-# and validation;
-# merge star cat and PSF plots.
+# ShapePipe configuration file for single-exposures, MCCD PSF model.
+# Process exposures after masking, from star detection to PSF model.
 
 
 ## Default ShapePipe options
@@ -10,10 +9,11 @@
 VERBOSE = True
 
 # Name of run (optional) default: shapepipe_run
-RUN_NAME = run_sp_MsPl
+RUN_NAME = run_sp_MsPl_mccd_test
+#RUN_NAME = run_sp_MsPl_mccd_train
 
-# Add date and time to RUN_NAME, optional, default: False
-RUN_DATETIME = False
+# Add date and time to RUN_NAME, optional, default: True
+; RUN_DATETIME = False
 
 
 ## ShapePipe execution options
@@ -22,7 +22,7 @@ RUN_DATETIME = False
 # Module name, single string or comma-separated list of valid module runner names
 MODULE = merge_starcat_runner, mccd_plots_runner
 
-# Parallel processing mode, SMP or MPI
+# Run mode, SMP or MPI
 MODE = SMP
 
 
@@ -35,8 +35,8 @@ LOG_NAME = log_sp
 # Runner log file name, optional, default: shapepipe_runs
 RUN_LOG_NAME = log_run_sp
 
-# Input directory, containing input files, single string or list of names
-INPUT_DIR = $SP_RUN/psf_validation_ind
+# Input directory, containing input files, single string or list of names with length matching FILE_PATTERN
+INPUT_DIR = output
 
 # Output directory
 OUTPUT_DIR = $SP_RUN/output
@@ -46,40 +46,45 @@ OUTPUT_DIR = $SP_RUN/output
 [JOB]
 
 # Batch size of parallel processing (optional), default is 1, i.e. run all jobs in serial
-SMP_BATCH_SIZE = 4
+SMP_BATCH_SIZE = 20
 
 # Timeout value (optional), default is None, i.e. no timeout limit applied
 TIMEOUT = 96:00:00
 
 
 ## Module options
+
 [MERGE_STARCAT_RUNNER]
 
-INPUT_DIR = psf_validation_ind
+# Path to MCCD config file
+CONFIG_PATH = $SP_CONFIG/config_MCCD.ini
+
+MODE = FIT_VALIDATION
+
+VERBOSE = False
+
+NUMBERING_SCHEME = -0000000
+
+INPUT_DIR = ./output/run_sp_Pl_2023-06-12_16-32-53/mccd_val_runner/output 
+#INPUT_DIR = output/run_sp_Pl_2023-07-03_09-25-58/mccd_val_runner/output/
 
 PSF_MODEL = mccd
 
-NUMBERING_SCHEME = -0000000
-
-# Input file pattern(s), list of strings with length matching number of expected input file types
-# Cannot contain wild cards
-FILE_PATTERN = validation_psf
-
-# FILE_EXT (optional) list of string extensions to identify input files
-FILE_EXT = .fits
-
-
 [MCCD_PLOTS_RUNNER]
 
-# NUMBERING_SCHEME (optional) string with numbering pattern for input files
-NUMBERING_SCHEME = -0000000
+# Path to MCCD config file
+CONFIG_PATH = $SP_CONFIG/config_MCCD.ini
 
-FILE_PATTERN = full_starcat
-FILE_EXT = .fits
+MODE = FIT_VALIDATION
+
+VERBOSE = False
+
+# Now MCCD has created a focal-plane PSF model, including all CCDS per images,
+# thus single-exposure files
+NUMBERING_SCHEME = -0000000
 
 PSF = mccd
 
-# Options for focal-plane plots                                                 
 PLOT_MEANSHAPES = True
 
 # X_GRID, Y_GRID: correspond to the number of bins in each direction of each
@@ -87,20 +92,44 @@ PLOT_MEANSHAPES = True
 X_GRID = 5
 Y_GRID = 10
 
-# Optional: max values for elliptity and residual ellipticities
-MAX_E = 0.05
-MAX_DE = 0.005
-
 PLOT_HISTOGRAMS = True
 
 # REMOVE_OUTLIERS: Remove validated stars that are outliers in terms of shape
 # before drawing the plots.
 REMOVE_OUTLIERS = False
 
-# Options for rho statistics plots                                              
 PLOT_RHO_STATS = True
 
+RHO_STATS_YLIM_L = 1e-7, 2e-4
+RHO_STATS_YLIM_R = 1e-5, 2e-4
+
+# RHO_STATS_STYLE: can be 'HSC' or 'DES'
 RHO_STATS_STYLE = HSC
 
-RHO_STATS_YLIM_L = 1e-10, 4e-5
-RHO_STATS_YLIM_R = 1e-8, 4e-5
+
+[MCCD_INTERP_RUNNER]
+
+# MODE: Define the way the MCCD interpolation will run.
+#  CLASSIC for classical run.
+#  MULTI-EPOCH for multi epoch.
+MODE = CLASSIC
+
+# Position parameter names
+# for multi-epoch XWIN_WORLD,YWIN_WORLD
+# For classical XWIN_IMAGE,YWIN_IMAGE:
+POSITION_PARAMS = XWIN_IMAGE,YWIN_IMAGE
+
+# Get PSF shapes calculated and saved on the output dict
+GET_SHAPES = True
+
+# Directory with PSF models
+PSF_MODEL_DIR = /Users/tliaudat/Documents/PhD/codes/venv_p3/MCCD_pipeline_integration/test_val_data/fitted_model/
+
+# PSF model patterns
+PSF_MODEL_PATTERN = fitted_model
+
+# PSF model separator
+PSF_MODEL_SEPARATOR = -
+
+# For multi-epoch purposes
+ME_LOG_WCS = $SP_RUN/output/log_exp_headers.sqlite

--- a/example/cfis/config_Pl_mccd.ini
+++ b/example/cfis/config_Pl_mccd.ini
@@ -57,6 +57,8 @@ TIMEOUT = 96:00:00
 # NUMBERING_SCHEME (optional) string with numbering pattern for input files
 NUMBERING_SCHEME = -0000000
 
+INPUT_DIR = ./output/run_sp_Pl_2023-06-12_16-32-53/mccd_val_runner/output
+
 FILE_PATTERN = full_starcat
 FILE_EXT = .fits
 

--- a/example/cfis/config_tile_Sx_exp_mccd.ini
+++ b/example/cfis/config_tile_Sx_exp_mccd.ini
@@ -234,6 +234,13 @@ VERBOSE = False
 
 NUMBERING_SCHEME = -0000000
 
+INPUT_DIR = last:mccd_preprocessing_runner, last:mccd_fit_val_runner            
+                                                                                
+# Use test stars (20% random sub-sample not used for PSF model).
+# To use training stars (80% random sub-sample used for PSF model):
+# change test_star_selection to train_star_selection
+FILE_PATTERN = fitted_model, test_star_selection
+
 
 [MERGE_STARCAT_RUNNER]
 


### PR DESCRIPTION
## Summary

Right now the rho statistics use the test star sample by default.
This also adds features to use the training set.

Do not merge yet.

## Reviewer Checklist

- [ ] The PR targets the `develop` branch
- [ ] The PR is assigned to the developer
- [ ] The PR has appropriate labels
- [ ] The PR is included in appropriate projects and/or milestones
- [ ] The PR includes a clear description of the proposed changes
- [ ] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [ ] The code and documentation style match the current standards
- [ ] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [ ] API docs have been built and checked at least once (if relevant)
- [ ] All changed files have been checked and comments provided to the developer
- [ ] All of the reviewer's comments have been satisfactorily addressed by the developer
