### PR TITLE
Fix bug in post-processing script

### DIFF
--- a/scripts/python/merge_final_cat.py
+++ b/scripts/python/merge_final_cat.py
@@ -316,7 +316,6 @@ def main(argv=None):
         add_this_l = False
 
         # mark to add if correct extension, matches input pattern,
-        not `.npy` file
         if (
             this_l.endswith(ext)
             and (f'{param.input_name_base}' in this_l)


### PR DESCRIPTION
## Summary

Removed faulty line in merge final cat script, used in post-processing.

Solves #641.

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [x] All of the reviewer's comments have been satisfactorily addressed by the developer
