### PR TITLE
mccd focal-plane plots: fixed coordinate flips for psfex

### DIFF
--- a/example/cfis/config_Pl_psfex.ini
+++ b/example/cfis/config_Pl_psfex.ini
@@ -66,8 +66,11 @@ X_GRID = 5
 Y_GRID = 10
 
 # Optional: max values for elliptity and residual ellipticities
-MAX_E = 0.05
-MAX_DE = 0.005
+MAX_E = 0.1
+MAX_DE = 0.01
+MIN_R2 = 4.5
+MAX_R2 = 7
+MAX_DR2 = 0.03
 
 PLOT_HISTOGRAMS = True
 REMOVE_OUTLIERS = False

--- a/shapepipe/modules/mccd_package/mccd_plot_utilities.py
+++ b/shapepipe/modules/mccd_package/mccd_plot_utilities.py
@@ -377,12 +377,16 @@ def plot_meanshapes(
 
         xs_loc, ys_loc = all_X[ccd_mask] - x_shift, all_Y[ccd_mask] - y_shift
 
-        # swap axes to match CCD orientation and origin convention
-        ys_loc = loc2glob.y_npix - ys_loc + 1
+        if psf_model_type == 'mccd':
+            # swap axes to match CCD orientation and origin convention
+            ys_loc = loc2glob.y_npix - ys_loc + 1
 
         # digitalize into bins
         xbins = np.digitize(xs_loc, grid[0])
         ybins = np.digitize(ys_loc, grid[1])
+
+        if psf_model_type == 'psfex':
+            xbins, ybins = megacam_flip(xbins, ybins, ccd_nb, nb_pixel)
 
         for xb in range(nb_pixel[0]):
             for yb in range(nb_pixel[1]):
@@ -518,7 +522,7 @@ def plot_meanshapes(
         if max_r2:
             vmax = max_r2
         else:
-            vmax = nanmax(ccd_maps[:, :, 2])
+            vmax = np.nanmax(ccd_maps[:, :, 2])
         wind = [vmin, vmax]
         colorbar_ampl = 1
         title = (


### PR DESCRIPTION
## Summary

With the `psfex` PSF model the CCD MegaCam coordinate flips were not accounted for. This was correct in the old
MeanShapes.py stand-alone script. Now again fixed.

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [x] The PR has appropriate labels
- [x] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [x] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer
- [x] All of the reviewer's comments have been satisfactorily addressed by the developer
