### PR TITLE
Added cent-os to CI tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, centos-latest]
         python-version: [3.9]
 
     steps:


### PR DESCRIPTION
## Summary

Continuous integration is now also testing CENT-OS, useful since candide runs on that OS.

Solves #633 

## Reviewer Checklist

> Reviewers should tick the following boxes before approving and merging the PR.

- [ ] The PR targets the `develop` branch
- [ ] The PR is assigned to the developer
- [ ] The PR has appropriate labels
- [ ] The PR is included in appropriate projects and/or milestones
- [ ] The PR includes a clear description of the proposed changes
- [ ] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [ ] The code and documentation style match the current standards
- [ ] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [ ] API docs have been built and checked at least once (if relevant)
- [ ] All changed files have been checked and comments provided to the developer
- [ ] All of the reviewer's comments have been satisfactorily addressed by the developer
