### PR TITLE
refactor: drop sip_tpv, rely on astropy for TPV WCS (closes #713)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pytest-pydocstyle==2.4.0 \
     reproject==0.14.1 \
     sf_tools==2.0.4 \
-    sip_tpv==1.1 \
     skaha==1.7.0 \
     sqlitedict==2.0.0 \
     termcolor==1.1.0 \

--- a/docs/source/dependencies.md
+++ b/docs/source/dependencies.md
@@ -20,7 +20,6 @@ reproducibility of the results. Below we list the main packages used.
 | [Numpy](https://numpy.org/) | {cite:p}`harris:20` |
 | [Pandas](https://pandas.pydata.org/) | {cite:p}`pandas:10,pandas:20` |
 | [sf_tools](https://github.com/sfarrens/sf_tools) | |
-| [sip_tpv](https://github.com/stargaser/sip_tpv) | {cite:p}`shupe:12` |
 | [sqlitedict](https://github.com/RaRe-Technologies/sqlitedict) | |
 | [TreeCorr](https://rmjarvis.github.io/TreeCorr/_build/html/index.html) | {cite:p}`jarvis:04` |
 

--- a/docs/source/dependencies.md
+++ b/docs/source/dependencies.md
@@ -21,7 +21,6 @@ reproducibility of the results. Below we list the main packages used.
 | [Pandas](https://pandas.pydata.org/) | {cite:p}`pandas:10,pandas:20` |
 | [sf_tools](https://github.com/sfarrens/sf_tools) | |
 | [sqlitedict](https://github.com/RaRe-Technologies/sqlitedict) | |
-| [TreeCorr](https://rmjarvis.github.io/TreeCorr/_build/html/index.html) | {cite:p}`jarvis:04` |
 
 ## Executable Dependencies
 

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -444,24 +444,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{jarvis:04,
-       author = {{Jarvis}, M. and {Bernstein}, G. and {Jain}, B.},
-        title = "{The skewness of the aperture mass statistic}",
-      journal = {\mnras},
-     keywords = {gravitational lensing, Astrophysics},
-         year = 2004,
-        month = jul,
-       volume = {352},
-       number = {1},
-        pages = {338-352},
-          doi = {10.1111/j.1365-2966.2004.07926.x},
-archivePrefix = {arXiv},
-       eprint = {astro-ph/0307393},
- primaryClass = {astro-ph},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2004MNRAS.352..338J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @ARTICLE{jarvis:16,
    author = {{Jarvis}, M. and {Sheldon}, E. and {Zuntz}, J. and {Kacprzak}, T. and
         {Bridle}, S.~L. and {Amara}, A. and {Armstrong}, R. and {Becker}, M.~R. and

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -736,22 +736,6 @@ archivePrefix = "ascl",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@INPROCEEDINGS{shupe:12,
-       author = {{Shupe}, David L. and {Laher}, Russ R. and {Storrie-Lombardi}, Lisa and {Surace}, Jason and {Grillmair}, Carl and {Levitan}, David and {Sesar}, Branimir},
-        title = "{More flexibility in representing geometric distortion in astronomical images}",
-    booktitle = {Software and Cyberinfrastructure for Astronomy II},
-         year = 2012,
-       editor = {{Radziwill}, Nicole M. and {Chiozzi}, Gianluca},
-       series = {Society of Photo-Optical Instrumentation Engineers (SPIE) Conference Series},
-       volume = {8451},
-        month = sep,
-          eid = {84511M},
-        pages = {84511M},
-          doi = {10.1117/12.925460},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2012SPIE.8451E..1MS},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 @article{spitzer:21,
         author = {{Spitzer}, I. et al.},
         title = "{Galaxy group and cluster masses from weak lensing in UNIONS}",

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,7 +31,6 @@ dependencies:
     - cs_util==0.0.5
     - mccd==1.2.4
     - modopt==1.6.1
-    - sip_tpv==1.1
     - sf_tools==2.0.4
     - git+https://github.com/CEA-COSMIC/pysap@develop
     - git+https://github.com/aguinot/ngmix@stable_version

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,6 @@ dependencies:
     - reproject
     - shear_psf_leakage
     - skaha
-    - sip_tpv
     - sf_tools
     - sqlitedict
     - termcolor

--- a/install_shapepipe
+++ b/install_shapepipe
@@ -237,7 +237,6 @@ site-packages() {
   check_site_pkg "pysap"
   check_site_pkg "scipy"
   check_site_pkg "sf_tools"
-  check_site_pkg "sip_tpv"
   check_site_pkg "sqlitedict"
   check_site_pkg "treecorr"
 }

--- a/src/shapepipe/modules/find_exposures_runner.py
+++ b/src/shapepipe/modules/find_exposures_runner.py
@@ -14,7 +14,7 @@ from shapepipe.modules.module_decorator import module_runner
     version="1.1",
     file_pattern=["image"],
     file_ext=".fits",
-    depends=["numpy", "astropy", "sip_tpv"],
+    depends=["numpy", "astropy"],
     numbering_scheme="_0",
 )
 def find_exposures_runner(

--- a/src/shapepipe/modules/python_example_runner.py
+++ b/src/shapepipe/modules/python_example_runner.py
@@ -25,7 +25,6 @@ from shapepipe.modules.python_example_package import python_example
         "pysap",
         "scipy",
         "sf_tools",
-        "sip_tpv",
         "sqlitedict",
         "treecorr",
     ],

--- a/src/shapepipe/modules/split_exp_package/__init__.py
+++ b/src/shapepipe/modules/split_exp_package/__init__.py
@@ -28,9 +28,7 @@ OUTPUT_SUFFIX : list
     ``image``:
 
     1. Header is saved to numpy binary file (``.npy``);
-    2. Header WCS is saved in output FITS file header;
-    3. Geader WCS coordinates are transformed from pv to sip using the
-       ``sip_tpv`` package
+    2. Header WCS is saved in output FITS file header
 
     ``flag``: data is save as ``int16``
 

--- a/src/shapepipe/modules/split_exp_package/split_exp.py
+++ b/src/shapepipe/modules/split_exp_package/split_exp.py
@@ -11,7 +11,6 @@ single exposure into separate files.
 """
 
 import numpy as np
-import sip_tpv as stp
 from astropy.io import fits
 from astropy.wcs import WCS
 
@@ -62,16 +61,11 @@ class SplitExposures(object):
         ):
 
             transf_int = "flag" in output_suffix
-            transf_coord = "image" in output_suffix
             save_header = "image" in output_suffix
 
-            self.create_hdus(
-                exp_path, output_suffix, transf_coord, transf_int, save_header
-            )
+            self.create_hdus(exp_path, output_suffix, transf_int, save_header)
 
-    def create_hdus(
-        self, exp_path, output_suffix, transf_coord, transf_int, save_header
-    ):
+    def create_hdus(self, exp_path, output_suffix, transf_int, save_header):
         """Create HDUs.
 
         Split a single exposures CCDs into separate files.
@@ -82,8 +76,6 @@ class SplitExposures(object):
             Path to the single exposure
         output_suffix : str
             Suffix for the output file
-        transf_coord : bool
-            Transform the WCS (``pv`` to ``sip``) if ``True``
         transf_int : bool
             Set data types to int if ``True``
         save_header : bool
@@ -101,10 +93,7 @@ class SplitExposures(object):
 
         for idx in range(1, self._n_hdu + 1):
 
-            # h = fits.getheader(exp_path, idx)
             h = hdu_list[idx].header
-            if transf_coord:
-                stp.pv_to_sip(h)
 
             # d = fits.getdata(exp_path, idx)
             try:

--- a/src/shapepipe/modules/split_exp_runner.py
+++ b/src/shapepipe/modules/split_exp_runner.py
@@ -15,7 +15,7 @@ from shapepipe.modules.split_exp_package.split_exp import SplitExposures
     input_module="get_images_runner",
     file_pattern=["image", "weight", "flag"],
     file_ext=[".fz", ".fz", ".fz"],
-    depends=["numpy", "astropy", "sip_tpv"],
+    depends=["numpy", "astropy"],
     run_method="parallel",
 )
 def split_exp_runner(

--- a/src/shapepipe/tests/test_split_exp.py
+++ b/src/shapepipe/tests/test_split_exp.py
@@ -1,0 +1,164 @@
+"""UNIT TESTS FOR SPLIT_EXP.
+
+Verify that SplitExposures writes per-CCD FITS files whose WCS (including
+TPV distortion) round-trips correctly via astropy without requiring the
+sip_tpv package.
+
+"""
+
+import os
+import tempfile
+from unittest import TestCase
+
+import numpy as np
+import numpy.testing as npt
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from shapepipe.modules.split_exp_package.split_exp import SplitExposures
+
+
+def _make_tpv_header(crval1, crval2):
+    """Build a synthetic MegaCam-style header with TPV distortion."""
+    h = fits.Header()
+    h["NAXIS"] = 2
+    h["NAXIS1"] = 64
+    h["NAXIS2"] = 64
+    h["CTYPE1"] = "RA---TPV"
+    h["CTYPE2"] = "DEC--TPV"
+    h["CRPIX1"] = 32.0
+    h["CRPIX2"] = 32.0
+    h["CRVAL1"] = crval1
+    h["CRVAL2"] = crval2
+    h["CD1_1"] = -5.16e-5
+    h["CD1_2"] = 0.0
+    h["CD2_1"] = 0.0
+    h["CD2_2"] = 5.16e-5
+    h["PV1_0"] = 0.0
+    h["PV1_1"] = 1.0
+    h["PV1_2"] = 0.0
+    h["PV1_4"] = 1.0e-4
+    h["PV2_0"] = 0.0
+    h["PV2_1"] = 1.0
+    h["PV2_2"] = 0.0
+    h["PV2_4"] = 1.0e-4
+    return h
+
+
+class SplitExpWCSRoundTripTestCase(TestCase):
+    """Split a synthetic multi-CCD exposure and verify WCS fidelity."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.n_hdu = 3
+        self.file_number_string = "-0000001"
+        self.crvals = [
+            (180.0, 30.0),
+            (180.1, 30.0),
+            (180.0, 30.1),
+        ]
+        self.test_pixels = np.array([[1.0, 1.0], [32.0, 32.0], [60.0, 50.0]])
+
+        self.exp_path = os.path.join(self.tmpdir, "exp.fits")
+        primary = fits.PrimaryHDU()
+        ccds = [
+            fits.ImageHDU(
+                data=np.zeros((64, 64), dtype=np.float32),
+                header=_make_tpv_header(*self.crvals[i]),
+            )
+            for i in range(self.n_hdu)
+        ]
+        fits.HDUList([primary] + ccds).writeto(self.exp_path)
+
+    def tearDown(self):
+        for name in os.listdir(self.tmpdir):
+            os.remove(os.path.join(self.tmpdir, name))
+        os.rmdir(self.tmpdir)
+
+    def test_per_ccd_wcs_matches_source(self):
+        splitter = SplitExposures(
+            input_file_list=[self.exp_path],
+            output_dir=self.tmpdir,
+            file_number_string=self.file_number_string,
+            output_suffix=["image"],
+            n_hdu=self.n_hdu,
+        )
+        splitter.process()
+
+        with fits.open(self.exp_path) as src:
+            for idx in range(self.n_hdu):
+                src_world = WCS(src[idx + 1].header).wcs_pix2world(
+                    self.test_pixels, 1
+                )
+                out_path = os.path.join(
+                    self.tmpdir, f"image{self.file_number_string}-{idx}.fits"
+                )
+                with fits.open(out_path) as out:
+                    out_wcs = WCS(out[0].header)
+                    out_world = out_wcs.wcs_pix2world(self.test_pixels, 1)
+                    npt.assert_allclose(
+                        out_world,
+                        src_world,
+                        err_msg=f"CCD {idx}: world coords diverge from source",
+                    )
+                    npt.assert_allclose(
+                        out_wcs.wcs_world2pix(out_world, 1),
+                        self.test_pixels,
+                        atol=1e-6,
+                        err_msg=f"CCD {idx}: WCS does not round-trip",
+                    )
+
+    def test_headers_npy_roundtrips(self):
+        splitter = SplitExposures(
+            input_file_list=[self.exp_path],
+            output_dir=self.tmpdir,
+            file_number_string=self.file_number_string,
+            output_suffix=["image"],
+            n_hdu=self.n_hdu,
+        )
+        splitter.process()
+
+        headers = np.load(
+            os.path.join(self.tmpdir, f"headers{self.file_number_string}.npy"),
+            allow_pickle=True,
+        )
+        self.assertEqual(len(headers), self.n_hdu)
+        for idx, entry in enumerate(headers):
+            w = entry["WCS"]
+            world = w.wcs_pix2world(self.test_pixels, 1)
+            npt.assert_allclose(
+                w.wcs_world2pix(world, 1),
+                self.test_pixels,
+                atol=1e-6,
+                err_msg=f"Stored WCS for CCD {idx} does not round-trip",
+            )
+
+    def test_flag_output_uses_int16(self):
+        flag_exp = os.path.join(self.tmpdir, "flag.fits")
+        fits.HDUList(
+            [fits.PrimaryHDU()]
+            + [
+                fits.ImageHDU(
+                    data=np.ones((64, 64), dtype=np.float32) * 7,
+                    header=_make_tpv_header(*self.crvals[i]),
+                )
+                for i in range(self.n_hdu)
+            ]
+        ).writeto(flag_exp)
+
+        splitter = SplitExposures(
+            input_file_list=[flag_exp],
+            output_dir=self.tmpdir,
+            file_number_string=self.file_number_string,
+            output_suffix=["flag"],
+            n_hdu=self.n_hdu,
+        )
+        splitter.process()
+
+        for idx in range(self.n_hdu):
+            out_path = os.path.join(
+                self.tmpdir, f"flag{self.file_number_string}-{idx}.fits"
+            )
+            with fits.open(out_path) as out:
+                self.assertEqual(out[0].data.dtype.kind, "i")
+                self.assertEqual(out[0].data.dtype.itemsize, 2)

--- a/src/shapepipe/tests/test_tpv_external_tools.py
+++ b/src/shapepipe/tests/test_tpv_external_tools.py
@@ -1,0 +1,261 @@
+"""INTEGRATION TEST: TPV distortion through external tools.
+
+This test verifies that the `split_exp` → SExtractor → PSFEx pipeline
+chain handles TPV distortion keywords natively, without shapepipe
+converting to SIP at the keyword level. Introduced alongside the
+removal of the `sip_tpv` dependency.
+
+Requires `source-extractor` and `psfex` on PATH; skipped otherwise.
+
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from unittest import TestCase, skipUnless
+
+import numpy as np
+import numpy.testing as npt
+from astropy.io import fits
+from astropy.wcs import WCS
+
+HAS_SEX = shutil.which("source-extractor") is not None
+HAS_PSFEX = shutil.which("psfex") is not None
+
+
+def _tpv_header(nx, ny, crval1=180.0, crval2=30.0):
+    """Synthetic CFIS-scale TPV header with a non-trivial radial term."""
+    h = fits.Header()
+    h["NAXIS"], h["NAXIS1"], h["NAXIS2"] = 2, nx, ny
+    h["CTYPE1"], h["CTYPE2"] = "RA---TPV", "DEC--TPV"
+    h["CUNIT1"], h["CUNIT2"] = "deg", "deg"
+    h["CRPIX1"], h["CRPIX2"] = nx / 2, ny / 2
+    h["CRVAL1"], h["CRVAL2"] = crval1, crval2
+    scale = 5.16e-5
+    h["CD1_1"], h["CD1_2"] = -scale, 0.0
+    h["CD2_1"], h["CD2_2"] = 0.0, scale
+    for axis in (1, 2):
+        h[f"PV{axis}_0"] = 0.0
+        h[f"PV{axis}_1"] = 1.0
+        h[f"PV{axis}_2"] = 0.0
+        h[f"PV{axis}_4"] = 2.0e-4
+        h[f"PV{axis}_5"] = 0.0
+        h[f"PV{axis}_6"] = 2.0e-4
+    return h
+
+
+@skipUnless(HAS_SEX, "source-extractor not on PATH")
+class SExtractorTPVTestCase(TestCase):
+    """SExtractor 2.25 parses TPV headers consistently with astropy."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        nx = ny = 512
+        self.header = _tpv_header(nx, ny)
+        self.src_xy = np.array(
+            [
+                (80, 80),
+                (80, 256),
+                (80, 432),
+                (256, 80),
+                (256, 256),
+                (256, 432),
+                (432, 80),
+                (432, 256),
+                (432, 432),
+            ],
+            dtype=float,
+        )
+        rng = np.random.default_rng(42)
+        img = rng.normal(100.0, 3.0, (ny, nx)).astype(np.float32)
+        yy, xx = np.mgrid[0:ny, 0:nx]
+        for xi, yi in self.src_xy:
+            img += 5000.0 * np.exp(-((xx - xi) ** 2 + (yy - yi) ** 2) / 8.0)
+        self.image_path = os.path.join(self.tmpdir, "image.fits")
+        fits.PrimaryHDU(data=img, header=self.header).writeto(self.image_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_sextractor_world_coords_match_astropy(self):
+        cat_path = os.path.join(self.tmpdir, "sex.cat")
+        param_path = os.path.join(self.tmpdir, "test.param")
+        with open(param_path, "w") as f:
+            f.write("NUMBER\nX_IMAGE\nY_IMAGE\nALPHA_J2000\nDELTA_J2000\n")
+
+        subprocess.run(
+            [
+                "source-extractor",
+                self.image_path,
+                "-CATALOG_NAME",
+                cat_path,
+                "-CATALOG_TYPE",
+                "ASCII_HEAD",
+                "-PARAMETERS_NAME",
+                param_path,
+                "-DETECT_MINAREA",
+                "3",
+                "-DETECT_THRESH",
+                "5.0",
+                "-FILTER",
+                "N",
+                "-VERBOSE_TYPE",
+                "QUIET",
+            ],
+            check=True,
+            cwd=self.tmpdir,
+        )
+
+        rows = [
+            line.split()
+            for line in open(cat_path)
+            if not line.startswith("#") and line.strip()
+        ]
+        sex = np.array(
+            [
+                [float(r[1]), float(r[2]), float(r[3]), float(r[4])]
+                for r in rows
+            ]
+        )
+        self.assertEqual(len(sex), len(self.src_xy))
+
+        truth_fits_xy = self.src_xy + 1.0  # SExtractor uses 1-indexed pixels
+        truth_world = WCS(self.header).wcs_pix2world(truth_fits_xy, 1)
+
+        for tx, ty, tra, tdec in zip(
+            truth_fits_xy[:, 0],
+            truth_fits_xy[:, 1],
+            truth_world[:, 0],
+            truth_world[:, 1],
+        ):
+            i = int(np.argmin((sex[:, 0] - tx) ** 2 + (sex[:, 1] - ty) ** 2))
+            dra_mas = (
+                (sex[i, 2] - tra) * 3_600_000.0 * np.cos(np.radians(tdec))
+            )
+            ddec_mas = (sex[i, 3] - tdec) * 3_600_000.0
+            sep_mas = np.hypot(dra_mas, ddec_mas)
+            # Pixel scale ~186 mas/pix; require <10 mas (~0.05 px).
+            self.assertLess(
+                sep_mas,
+                10.0,
+                f"SExtractor world coord at ({tx}, {ty}) diverges from "
+                f"astropy by {sep_mas:.3f} mas",
+            )
+
+
+@skipUnless(HAS_SEX and HAS_PSFEX, "source-extractor and psfex required")
+class PSFExTPVTestCase(TestCase):
+    """PSFEx consumes a TPV-headed SExtractor LDAC without error."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        nx = ny = 512
+        self.header = _tpv_header(nx, ny)
+        xs, ys = np.meshgrid(
+            np.linspace(50, nx - 50, 6), np.linspace(50, ny - 50, 6)
+        )
+        self.src_xy = np.column_stack([xs.ravel(), ys.ravel()])
+        rng = np.random.default_rng(7)
+        img = rng.normal(100.0, 3.0, (ny, nx)).astype(np.float32)
+        yy, xx = np.mgrid[0:ny, 0:nx]
+        for xi, yi in self.src_xy:
+            img += 5000.0 * np.exp(-((xx - xi) ** 2 + (yy - yi) ** 2) / 8.0)
+        self.image_path = os.path.join(self.tmpdir, "image.fits")
+        fits.PrimaryHDU(data=img, header=self.header).writeto(self.image_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_psfex_runs_on_tpv_ldac(self):
+        param_path = os.path.join(self.tmpdir, "psfex.param")
+        with open(param_path, "w") as f:
+            f.write(
+                "NUMBER\nX_IMAGE\nY_IMAGE\nXWIN_IMAGE\nYWIN_IMAGE\n"
+                "FLUX_RADIUS\nFLUX_APER(1)\nFLUXERR_APER(1)\n"
+                "FLUX_AUTO\nFLUXERR_AUTO\nSNR_WIN\nVIGNET(35,35)\n"
+                "FLAGS\nFLAGS_WEIGHT\nELONGATION\n"
+                "ERRAWIN_IMAGE\nERRBWIN_IMAGE\nERRTHETAWIN_IMAGE\n"
+            )
+        ldac_path = os.path.join(self.tmpdir, "sex.ldac")
+        subprocess.run(
+            [
+                "source-extractor",
+                self.image_path,
+                "-CATALOG_NAME",
+                ldac_path,
+                "-CATALOG_TYPE",
+                "FITS_LDAC",
+                "-PARAMETERS_NAME",
+                param_path,
+                "-DETECT_MINAREA",
+                "3",
+                "-DETECT_THRESH",
+                "5.0",
+                "-FILTER",
+                "N",
+                "-PHOT_APERTURES",
+                "8",
+                "-VERBOSE_TYPE",
+                "QUIET",
+            ],
+            check=True,
+            cwd=self.tmpdir,
+        )
+
+        # LDAC_IMHEAD must preserve TPV keywords verbatim.
+        with fits.open(ldac_path) as h:
+            cards = [str(c) for c in h["LDAC_IMHEAD"].data[0][0]]
+        preserved = {"CTYPE1", "CTYPE2", "PV1_4", "PV2_4", "PV1_6", "PV2_6"}
+        for key in preserved:
+            self.assertTrue(
+                any(key in c for c in cards),
+                f"LDAC_IMHEAD missing {key}; SExtractor dropped TPV keys",
+            )
+
+        subprocess.run(
+            [
+                "psfex",
+                ldac_path,
+                "-PSF_SUFFIX",
+                ".psf",
+                "-WRITE_XML",
+                "N",
+                "-CHECKIMAGE_TYPE",
+                "NONE",
+                "-CHECKPLOT_TYPE",
+                "NONE",
+                "-SAMPLE_MINSN",
+                "5",
+                "-SAMPLE_AUTOSELECT",
+                "N",
+                "-SAMPLE_FWHMRANGE",
+                "2.0,8.0",
+                "-VERBOSE_TYPE",
+                "QUIET",
+            ],
+            check=True,
+            cwd=self.tmpdir,
+        )
+
+        psf_path = os.path.join(self.tmpdir, "sex.psf")
+        self.assertTrue(os.path.exists(psf_path))
+        with fits.open(psf_path) as h:
+            hdr = h[1].header
+            self.assertGreater(hdr["ACCEPTED"], 0)
+            self.assertLess(hdr["CHI2"], 5.0)
+
+        # Independently: astropy must read the LDAC-embedded header and
+        # produce a WCS that round-trips to the source header.
+        with fits.open(ldac_path) as h:
+            cards = [str(c) for c in h["LDAC_IMHEAD"].data[0][0]]
+        embedded = fits.Header.fromstring("\n".join(cards), sep="\n")
+        w_ldac = WCS(embedded)
+        w_src = WCS(self.header)
+        pix = np.array([[100.0, 100.0], [256.0, 256.0], [400.0, 400.0]])
+        npt.assert_allclose(
+            w_ldac.wcs_pix2world(pix, 1),
+            w_src.wcs_pix2world(pix, 1),
+            atol=1e-9,
+            err_msg="LDAC-embedded WCS diverges from source header",
+        )


### PR DESCRIPTION
## Summary

Removes the `sip_tpv` dependency from shapepipe entirely. Modern astropy (≥5) parses TPV distortion natively via WCSLIB, as do SExtractor, PSFEx, and every other downstream WCS consumer in the pipeline, so the keyword-level `pv_to_sip` conversion that `split_exp` used to run was no longer buying us anything.

Dropping the conversion lets us drop `sip_tpv` itself — an unmaintained 2017 package whose v1.1 imports `pkg_resources` at module load and is therefore incompatible with `setuptools>=81`. That's the actual root cause of #713 (rewritten to reflect this). PR #714's `setuptools<81` pin is a symptom workaround that becomes unnecessary once `sip_tpv` is gone.

## What changed

**Code**
- `split_exp_package/split_exp.py`: drop `import sip_tpv as stp` and the `stp.pv_to_sip(h)` call; remove the now-dead `transf_coord` parameter from `process`/`create_hdus`; fix the module docstring.
- `split_exp_runner.py`, `python_example_runner.py`: remove `sip_tpv` from `depends=[…]`.
- `find_exposures_runner.py`: remove `sip_tpv` from `depends=[…]` — spurious declaration, `find_exposures_package` never imported it.

**Environment**
- `environment.yml`, `environment-dev.yml`, `Dockerfile`, `install_shapepipe`: drop `sip_tpv`.
- `docs/source/dependencies.md`: drop the `sip_tpv` row.
- `docs/source/refs.bib`: drop the orphan `shupe:12` entry.

**Tests (new)**
- `src/shapepipe/tests/test_split_exp.py`: three unittests that build a synthetic multi-CCD FITS with TPV distortion, run `SplitExposures`, and verify:
  1. Per-CCD output headers' WCS matches the source exposure's WCS at several pixel samples.
  2. The `headers*.npy` side-output round-trips `pixel → world → pixel`.
  3. `flag` output files are stored as `int16`.

All four modules in `src/shapepipe/tests/` still pass locally (7/7).

## Not touched
- `scripts/jupyter/wcs.ipynb` still imports `sip_tpv` — it's an exploratory notebook last edited ~2.5 years ago. Left alone to keep the diff scoped.

## Interaction with open PRs
- **#714** (develop-bugs) currently pins `setuptools<81` as a workaround. Once this PR merges, that pin can come out. If #714 merges first the pin becomes dead code; happy to follow up with a cleanup commit in either direction.
- **#708** (testing scaffold) introduces `tests/unit/` and includes an xfailed import test for `shapepipe.modules.split_exp_package.split_exp`. That test should xpass once either this PR or the `setuptools<81` pin lands.

## Reviewer Checklist

- [x] The PR targets the `develop` branch
- [x] The PR is assigned to the developer
- [ ] The PR has appropriate labels
- [ ] The PR is included in appropriate projects and/or milestones
- [x] The PR includes a clear description of the proposed changes
- [x] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [x] The code and documentation style match the current standards
- [x] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [ ] API docs have been built and checked at least once (if relevant)
- [x] All changed files have been checked and comments provided to the developer