### PR TITLE
chore: drop dead setuptools<81 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "PyQt5",
     "pyqtgraph",
     "reproject",
-    "setuptools<81", # workaround for sf_tools/python-pysap importing pkg_resources
     "sf_tools",
     "skaha",
     "sqlitedict",


### PR DESCRIPTION
## Summary

The pin's comment attributes it to "sf_tools/python-pysap importing pkg_resources", but both claims are wrong. Empirical check in the current shapepipe container:

- `sf_tools 2.0.4` imports cleanly on `setuptools 82.0.0`
- `python-pysap` has no `pkg_resources` usage on master
- The **only** shapepipe runtime dep that used `pkg_resources` was `sip_tpv` (via `pkg_resources.get_distribution("sip_tpv")` in `__init__.py`), which was removed in #716

So the real historical reason for the pin was `sip_tpv`, mis-attributed in the comment. Post-#716 there's no remaining shapepipe runtime dep that needs `pkg_resources`, so the pin is dead.

Should arguably have been included in #716 — here we are.

## Test plan

- [x] `sf_tools` imports on setuptools 82 in the current container
- [x] `python-pysap` source inspection (master) — no `pkg_resources` usage
- [ ] Container builds and `shapepipe_run -c example/config.ini` runs after the pin is removed (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)