### PR TITLE
Fix centroid shift

### DIFF
--- a/src/shapepipe/modules/ngmix_package/ngmix.py
+++ b/src/shapepipe/modules/ngmix_package/ngmix.py
@@ -366,7 +366,7 @@ class Ngmix(object):
             if id_last != cat._cat_data[hdu_no].data["id"][-1]:
                 raise ValueError(
                     "Last ID {cat._cat_data[hdu_no].data['id'][-1]} in HDU"
-                    + f" #{hdu_no} inconsistent with {id_las}"
+                    + f" #{hdu_no} inconsistent with {id_last}"
                 )
 
         return id_last
@@ -1026,7 +1026,10 @@ def do_ngmix_metacal(
         # Gal guess
         try:
             gal_guess_tmp = get_guess(
-                gals[n_e], pixel_scale, guess_size_type="sigma"
+                gals[n_e],
+                pixel_scale,
+                guess_size_type="T",
+                guess_centroid_unit="img",
             )
         except Exception:
             gal_guess_flag = False
@@ -1034,8 +1037,8 @@ def do_ngmix_metacal(
 
         # Recenter jacobian if necessary
         gal_jacob = ngmix.Jacobian(
-            row=(gals[0].shape[0] - 1) / 2 + gal_guess_tmp[0],
-            col=(gals[0].shape[1] - 1) / 2 + gal_guess_tmp[1],
+            row=(gals[n_e].shape[0] - 1) / 2 + gal_guess_tmp[1],
+            col=(gals[n_e].shape[1] - 1) / 2 + gal_guess_tmp[0],
             wcs=jacob_list[n_e],
         )
 

--- a/src/shapepipe/modules/ngmix_package/ngmix.py
+++ b/src/shapepipe/modules/ngmix_package/ngmix.py
@@ -1028,7 +1028,6 @@ def do_ngmix_metacal(
             gal_guess_tmp = get_guess(
                 gals[n_e],
                 pixel_scale,
-                guess_size_type="T",
                 guess_centroid_unit="img",
             )
         except Exception:


### PR DESCRIPTION
## Summary

Fix the unit of the centroid guess and (row; col) / (x; y) order. Maybe there is something better to do than setting it to 0 incase the guess fails.
Also fix the size type as `get_noise` expect `T` instead of `sigma`. This is not a huge bug because the size was overestimated.
(Fix a small typo)

## Reviewer Checklist

- [ ] The PR targets the `develop` branch
- [ ] The PR is assigned to the developer
- [ ] The PR has appropriate labels
- [ ] The PR is included in appropriate projects and/or milestones
- [ ] The PR includes a clear description of the proposed changes
- [ ] If the PR addresses an open issue the description includes "closes #<ISSUE NUMBER>"
- [ ] The code and documentation style match the current standards
- [ ] Documentation has been added/updated consistently with the code
- [ ] All CI tests are passing
- [ ] API docs have been built and checked at least once (if relevant)
- [ ] All changed files have been checked and comments provided to the developer
- [ ] All of the reviewer's comments have been satisfactorily addressed by the developer
