### PR TITLE
chore: add dependabot.yml + SHA-pin all GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot config — supply-chain conservative posture.
+#
+# Why this exists:
+#   - We now ship a `uv.lock`, so Dependabot's security-updates channel fires
+#     automatically on GHSAs touching transitive deps. This file adds
+#     *version-updates* policy on top: routine bumps that don't fall out
+#     of a security advisory.
+#   - 2025-2026 has seen a wave of maintainer-compromise attacks across npm
+#     and PyPI (Shai-Hulud / Mini Shai-Hulud, axios, PyTorch Lightning,
+#     tj-actions/changed-files, …). The published-to-Dependabot-PR-lag is
+#     often minutes. Cooldown buys a detection window for free.
+#
+# Policy:
+#   - 14-day cooldown on minor/patch (30 days on majors). Anything malicious
+#     is usually caught and yanked within a few days; the cooldown lets that
+#     happen before it reaches us.
+#   - Monthly schedule + grouped patch/minor PRs — one batched PR per month,
+#     atomic to revert, large enough to actually be reviewed.
+#   - Major bumps stay as individual PRs (potentially breaking; each
+#     deserves its own review).
+#   - No auto-merge anywhere. Lockfile diffs are uninspectable; we eyeball
+#     the version metadata and source links before merging.
+#
+# Note: cooldown does NOT apply to security-updates (the GHSA-driven PRs).
+# Those still fire on the CVE-publication timeline, which is the right
+# tradeoff for shapepipe — fix CVEs fast, but don't auto-merge them either.
+
+version: 2
+
+updates:
+  # Python dependencies tracked via uv.lock
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
+    groups:
+      lockfile-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+
+  # GitHub Actions versions (SHA-pinned in workflows; Dependabot proposes
+  # SHA bumps with the new tag annotated in the PR body).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 14
+    groups:
+      actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2.3.0
         with:
           auto-update-conda: true
           python-version: 3.9
@@ -38,7 +38,7 @@ jobs:
           sphinx-build -E docs/source docs/_build
 
       - name: Deploy API documentation
-        uses: peaceiris/actions-gh-pages@v3.5.9
+        uses: peaceiris/actions-gh-pages@cf301857435c1f95963b21d58f452a7617770d60 # v3.5.9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: [3.11]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -35,7 +35,7 @@ jobs:
           brew reinstall gcc
 
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -11,17 +11,17 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver-opts: network=host
 
@@ -29,13 +29,13 @@ jobs:
       # `:develop`); `runtime` carries a `-runtime` suffix.
       - name: Tags — dev (default)
         id: meta-dev
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Tags — runtime
         id: meta-runtime
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -43,7 +43,7 @@ jobs:
 
       # Build runtime first (smaller, used to smoke-test pipeline binaries)
       - name: Build runtime (load)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           target: runtime
@@ -70,7 +70,7 @@ jobs:
 
       # Build dev (reuses cached `base` layer)
       - name: Build dev (load)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           target: dev
@@ -90,7 +90,7 @@ jobs:
 
       # Push both targets
       - name: Push runtime
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           target: runtime
@@ -100,7 +100,7 @@ jobs:
           cache-from: type=gha
 
       - name: Push dev
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           target: dev

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35 # v2.3.0
         with:
           auto-update-conda: true
           python-version: 3.8
@@ -33,7 +33,7 @@ jobs:
           sphinx-build -E docs/source docs/_build
 
       - name: Archive API build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
           name: api-docs
           retention-days: 14


### PR DESCRIPTION
## Summary

Two related supply-chain-conservative hygiene changes for the post-`uv.lock` era:

1. **`.github/dependabot.yml`** — explicit version-updates policy with **14-day cooldown** on minor/patch (30 days on majors), **monthly grouped lockfile PRs**, and **github-actions ecosystem** opted in. Companion to the security-updates channel that fires automatically since `uv.lock` landed (#719).
2. **SHA-pin every GitHub Action** across all four workflows. Human-readable tag preserved as trailing comment so reviewers can still see what version they're looking at.

No behavioral change intended; SHAs resolved against current refs of the same tags that were referenced before.

## Why now

Six dependabot security PRs accumulated against `uv.lock` between 2026-05-05 and now (being triaged separately). That backlog made the absence of a dependabot.yml visible. While digging in, two things sharpened the posture:

- **Maintainer-compromise attacks** ([Shai-Hulud / Mini Shai-Hulud worm](https://thehackernews.com/2026/05/mini-shai-hulud-worm-compromises.html), axios March 2026, PyTorch Lightning, intercom-client) — attackers take over real maintainer accounts and push compromised versions of legitimate packages. In the axios case, Dependabot was PR'ing the malicious version to public repos within 5 minutes of upload. Cooldown is the documented [primitive defense](https://christian-schneider.net/blog/dependency-cooldowns-supply-chain-defense/) — a 7-day cooldown alone would have caught 8 of the 10 biggest 2025 attacks before they reached anyone's PRs. We're using 14 days.
- **Mutable action tags** — [tj-actions/changed-files](https://thehackernews.com/2026/05/github-actions-supply-chain-attack.html) (23k+ repos compromised in Q1 2026), Trivy, Nx — all via attackers re-pointing `@v4`-style tags at malicious SHAs. SHA-pinning closes that vector at the cost of less-readable workflow files; the trailing tag comment + Dependabot's SHA-bump PRs keep it tractable.

## Policy summary

| | What | Why |
|---|---|---|
| Cooldown | 14d minor/patch, 30d major | Detection window for upstream compromise |
| Schedule | Monthly grouped | One reviewable PR > six waved-through |
| Majors | Individual PRs | Breaking; each deserves attention |
| Auto-merge | Off | Lockfile diffs are uninspectable; humans gate |
| Security PRs | Still auto (separate channel) | Fix CVEs fast |

## Test plan

- [ ] CI passes (`build-and-push-image` should be unaffected — same actions, just SHA-pinned).
- [ ] After merge, no spurious Dependabot PRs immediately fire (cooldown should hold them back).
- [ ] Next month, observe whether the lockfile-minor-patch group fires as expected with a single grouped PR.
- [ ] Dependabot opens a github-actions PR proposing SHA bumps with new-tag annotations.

— Claude on behalf of Cail