### PR TITLE
docker: smoke-test the example pipeline in read-only mode

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -63,10 +63,13 @@ jobs:
           docker run --rm "$IMAGE" weightwatcher --version
           docker run --rm "$IMAGE" psfex --version
 
-      - name: Test runtime — shapepipe entry point
+      - name: Test runtime — shapepipe entry point (read-only fs)
         run: |
           IMAGE=$(echo "${{ steps.meta-runtime.outputs.tags }}" | head -n1)
-          docker run --rm "$IMAGE" shapepipe_run -c /app/example/config.ini
+          # --read-only + tmpfs /tmp emulates apptainer/SIF semantics: only
+          # /tmp is writable. shapepipe_run_example wraps shapepipe_run so
+          # the example tree gets copied into a mktemp workdir before running.
+          docker run --rm --read-only --tmpfs /tmp:rw "$IMAGE" shapepipe_run_example
 
       # Build dev (reuses cached `base` layer)
       - name: Build dev (load)

--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Ignore example output
-*shapepipe_run_*
-*shapepipe_runs*
+# Ignore example output (generated under example/output/ by shapepipe_run)
+example/output/shapepipe_run_*
+example/output/shapepipe_runs*
 code

--- a/scripts/sh/shapepipe_run_example.sh
+++ b/scripts/sh/shapepipe_run_example.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Run the bundled example pipeline against a writable copy of /app/example.
+#
+# Works under both docker (writable /app) and apptainer/SIF (read-only /app):
+# the example tree is copied into a fresh tmp workdir so the config's
+# relative paths (INPUT_DIR=./example/data/..., OUTPUT_DIR=./example/output)
+# resolve to writable locations.
+#
+# Extra args are forwarded to shapepipe_run, e.g.:
+#   shapepipe_run_example -v
+set -euo pipefail
+
+WORK="$(mktemp -d -t shapepipe-example-XXXXXX)"
+cp -r /app/example "$WORK/"
+cd "$WORK"
+exec shapepipe_run -c example/config.ini "$@"


### PR DESCRIPTION
## Summary

- Adds `scripts/sh/shapepipe_run_example.sh` — a small wrapper that mktemp's a workdir, copies `/app/example/` into it, cd's, and execs `shapepipe_run`. The existing Dockerfile auto-symlink rule (`scripts/<lang>/<name>.<ext>` → `/usr/local/bin/<name>`) makes it available as `shapepipe_run_example` on `$PATH`.
- Updates the CI smoke step in `deploy-image.yml` to call the wrapper, and runs it under `docker run --read-only --tmpfs /tmp:rw` — this emulates apptainer/SIF semantics, so the read-only constraint is now actually exercised in CI.
- Drive-by: tightens `.gitignore` from `*shapepipe_run_*` (which catches any path containing that substring, including the new wrapper) to `example/output/shapepipe_run_*`.

## Why

`shapepipe_run -c /app/example/config.ini` succeeds under docker because the container filesystem is writable. Under apptainer/SIF it fails:

```
ERROR: [Errno 30] Read-only file system: './example/output/shapepipe_runs.txt'
```

`OUTPUT_DIR=./example/output` resolves under `WORKDIR=/app`, which is read-only in SIF. CI was passing while the apptainer path silently broke — same class of gap dc13582e closed for `uv run pytest`, but for the pipeline entry point.

The wrapper closes the gap without changing user-facing config or the entry point. Same command works for both docker and apptainer users.

## Verified locally

Built a fresh `:develop` sandbox at `/n17data/cdaley/containers/shapepipe-712-check` and ran the wrapper logic via:

```
apptainer exec /n17data/cdaley/containers/shapepipe-712-check bash -c '
  set -euo pipefail
  WORK="$(mktemp -d -t shapepipe-example-XXXXXX)"
  cp -r /app/example "$WORK/"
  cd "$WORK"
  shapepipe_run -c example/config.ini
'
```

— pipeline runs all 5 module steps and ends with `A total of 0 errors were recorded. Finishing ShapePipe Run`.

## Test plan

- [ ] CI's `Test runtime — shapepipe entry point (read-only fs)` step passes (wrapper resolves on PATH; mktemp/cp/cd dance works under `--read-only --tmpfs /tmp:rw`)
- [ ] No other CI step regresses from the `.gitignore` retightening (the new pattern is strictly narrower)

🤖 Generated with [Claude Code](https://claude.com/claude-code)