### PR TITLE
fix: repair the CI test suite (conda.sh lookup + --env-dev flag)

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -52,12 +52,12 @@ jobs:
           CC: gcc-9
           CXX: g++-9
         if: runner.os == 'Linux'
-        run: ./install_shapepipe --develop
+        run: ./install_shapepipe --env-dev
 
       - name: Install package (macOS)
         shell: bash -l {0}
         if: runner.os == 'macOS'
-        run: ./install_shapepipe --develop
+        run: ./install_shapepipe --env-dev
 
       - name: Run tests
         shell: bash -l {0}

--- a/install_shapepipe
+++ b/install_shapepipe
@@ -119,15 +119,21 @@ check_conda() {
     echo -ne "${RED}ERROR: Found Conda version $CONDA_VERSION but require 4.0.0 or greater.${NC}\n"
     exit 1
   fi
-  # Look for conda.sh file
-  if [ -f "/opt/conda/$CONDA_SH" ]
+  # Look for conda.sh file. `conda info --base` is authoritative wherever conda
+  # lives (GitHub runners, miniforge, custom installs); fall back to the
+  # conventional locations for environments where it can't be queried.
+  CONDA_BASE=$(conda info --base 2>/dev/null)
+  if [ -n "$CONDA_BASE" ] && [ -f "$CONDA_BASE$CONDA_SH" ]
   then
-    source "/opt/conda/$CONDA_SH"
+    source "$CONDA_BASE$CONDA_SH"
+  elif [ -f "/opt/conda$CONDA_SH" ]
+  then
+    source "/opt/conda$CONDA_SH"
   elif [ -f "$CONDA_PREFIX$CONDA_SH" ]
   then
     source "$CONDA_PREFIX$CONDA_SH"
   else
-    echo -ne "${RED}ERROR: Could not find $CONDA_SH in /opt/conda or \$CONDA_PREFIX.${NC}\n"
+    echo -ne "${RED}ERROR: Could not find $CONDA_SH in \$(conda info --base), /opt/conda, or \$CONDA_PREFIX.${NC}\n"
     echo -ne "${RED}Activate the base/root Conda environment and try again.${NC}\n"
     exit 1
   fi


### PR DESCRIPTION
Turning on the `develop` CI trigger surfaced a chain of pre-existing failures in the test suite that had been invisible (CI only ran on PRs to `main`/`master`). This PR fixes the two that block the suite from running.

## 1. `install_shapepipe` couldn't find `conda.sh`

It only looked under `/opt/conda` (docker convention) or `$CONDA_PREFIX`, neither of which resolves on GitHub runners (`$CONDA_PREFIX` is empty in the install step's shell). Fixed by querying conda itself via `conda info --base`, with the old paths kept as fallbacks. Verified locally against a non-standard prefix (`/softs/intelpython/...`) the old logic would miss.

## 2. CI built the wrong conda environment

The install steps called `./install_shapepipe --develop`. But `--develop` only adds dev *pip* extras into the **production** env; the flag that builds the dev conda env (`shapepipe-dev`, from `environment-dev.yml`) is `--env-dev` (which also triggers `.[dev]` on its own). The downstream `Run tests` step already does `conda activate shapepipe-dev` — an env the old flag never created. Switched both install steps to `--env-dev`.

## Out of scope — separate production bug

`environment.yml` (production) is itself unsolvable: `astropy==5.2` (py38–py311 builds only) pinned against `python=3.12`. This breaks real production installs and deserves its own issue/PR; it's not on the dev-env path the test suite uses.

— Claude on behalf of Cail