### PR TITLE
chore(deps): group Dependabot security updates to cut PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,17 @@
 #     atomic to revert, large enough to actually be reviewed.
 #   - Major bumps stay as individual PRs (potentially breaking; each
 #     deserves its own review).
+#   - Security updates are grouped too (one batched PR per ecosystem) so a
+#     same-day burst of advisories arrives as a single PR, not one per package.
 #   - No auto-merge anywhere. Lockfile diffs are uninspectable; we eyeball
 #     the version metadata and source links before merging.
 #
-# Note: cooldown does NOT apply to security-updates (the GHSA-driven PRs).
-# Those still fire on the CVE-publication timeline, which is the right
-# tradeoff for shapepipe — fix CVEs fast, but don't auto-merge them either.
+# Note: cooldown and the monthly schedule do NOT apply to security-updates
+# (the GHSA-driven PRs) — only to version-updates. Security PRs still fire on
+# the CVE-publication timeline, which is the right tradeoff for shapepipe (fix
+# CVEs fast). The `applies-to: security-updates` groups below don't change that
+# timing; they only collapse a burst into one PR. Each `groups` block needs an
+# explicit `applies-to`, hence the paired version/security groups per ecosystem.
 
 version: 2
 
@@ -39,8 +44,12 @@ updates:
       semver-major-days: 30
     groups:
       lockfile-minor-patch:
+        applies-to: version-updates
         patterns: ["*"]
         update-types: ["minor", "patch"]
+      lockfile-security:
+        applies-to: security-updates
+        patterns: ["*"]
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
@@ -55,6 +64,10 @@ updates:
       default-days: 14
     groups:
       actions:
+        applies-to: version-updates
+        patterns: ["*"]
+      actions-security:
+        applies-to: security-updates
         patterns: ["*"]
     open-pull-requests-limit: 2
     labels:


### PR DESCRIPTION
## What

Adds an `applies-to: security-updates` group to each ecosystem in `.github/dependabot.yml` so a burst of security advisories batches into **one PR per ecosystem** instead of one PR per package.

## Why

The version-update side of our Dependabot config already works well — monthly schedule, 14-day cooldown, grouped minor/patch into a single PR. But Dependabot's **security-updates** channel (GHSA-driven) bypasses grouping, cooldown, *and* the schedule by default. So four security PRs landed the same day (cryptography, tornado, bleach, jupyter-server) — exactly the noise this change removes.

By default a `groups` block only applies to version-updates, so security PRs were never grouped. This adds a paired security group per ecosystem (and makes the existing groups' `applies-to: version-updates` explicit, which is required once a second group exists).

## What this does *not* change

Security PRs stay advisory-timed — cooldown and the monthly schedule apply **only** to version-updates, by design (fix CVEs fast). Grouping only collapses the count; it does not delay or auto-merge CVE fixes. No auto-merge is introduced anywhere.

— Claude on behalf of Cail

🤖 Generated with [Claude Code](https://claude.com/claude-code)