### PR TITLE
ci: run science guardrails as a fast fail-first lane

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -113,6 +113,21 @@ jobs:
           docker run --rm "$IMAGE" vim --version | head -n1
           docker run --rm "$IMAGE" rg --version | head -n1
 
+      # Fast science guardrails first (tests/science) — the tier of controlled
+      # simulations with a known answer (e.g. the m-bias check: inject g1=0.02,
+      # recover after the metacal response, assert |m| < 5e-3). These run in
+      # seconds and gate scientific correctness, so we fire them as their own
+      # named check *before* the full suite: a regression that breaks the
+      # response correction or deconvolution fails here in seconds, with a
+      # clear signal, instead of being buried minutes deep in the full run.
+      # `-m "not slow"` keeps this the fast lane (the science tier holds only
+      # fast tests today; the filter makes the intent explicit and future-proof).
+      - name: Test dev — science guardrails (fast)
+        run: |
+          IMAGE=$(echo "${{ steps.meta-dev.outputs.tags }}" | head -n1)
+          docker run --rm -e HYPOTHESIS_PROFILE=ci "$IMAGE" \
+            pytest -rX -m "not slow" --no-cov tests/science
+
       # The actual test suite, run inside the shipped image — replacing the
       # retired conda-based suite. pytest exercises the same wheels, binaries,
       # and Python (3.12) that production runs on, not a parallel environment.


### PR DESCRIPTION
Closes #764. Part of the #765 verification-suite epic (Tier 1: fast CI tripwires).

Adds a named step **"Test dev — science guardrails (fast)"** to `deploy-image.yml`, running `pytest -rX -m "not slow" --no-cov tests/science` inside the dev image *before* the full suite — so a shear-calibration regression fails the build immediately and legibly, rather than surfacing mid-way through the full run. The guardrails re-run inside the full suite afterwards; the duplication is the intended fail-fast cost (~seconds).

Sensitivity checked on the m-bias guardrail: the corrected `m = −2.0e-3` passes; dropping the response correction (`m = −7.8%`) and a 2× metacal-step mis-scale (`m = +100%`) both fail.

— Claude on behalf of Cail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4PVdk8w8vTxBuCahjGhXh