### PR TITLE
fix: raise constructed-but-discarded exceptions (Closes #785)

### DIFF
--- a/src/shapepipe/modules/mask_package/mask.py
+++ b/src/shapepipe/modules/mask_package/mask.py
@@ -1070,7 +1070,7 @@ class Mask(object):
                 self._WW_stdout, self._WW_stderr = execute(cmd)
 
         else:
-            ValueError("Types must be in ['HALO','SPIKE','ALL']")
+            raise ValueError("Types must be in ['HALO','SPIKE','ALL']")
 
         if (self._WW_stderr != "") or (self._rm_reg_stderr != ""):
             self._err = True

--- a/src/shapepipe/modules/mccd_interp_runner.py
+++ b/src/shapepipe/modules/mccd_interp_runner.py
@@ -114,13 +114,13 @@ def mccd_interp_runner(
         inst.process_me(psf_model_dir, psf_model_pattern, f_wcs_path)
 
     elif mode == "VALIDATION":
-        ValueError(
+        raise ValueError(
             "MODE has to be in MULTI-EPOCH or CLASSIC. For validation"
             + " use MCCD validation runner."
         )
 
     else:
-        ValueError("MODE has to be in : [CLASSIC, MULTI-EPOCH]")
+        raise ValueError("MODE has to be in : [CLASSIC, MULTI-EPOCH]")
 
     # No return objects
     return None, None

--- a/src/shapepipe/modules/psfex_interp_runner.py
+++ b/src/shapepipe/modules/psfex_interp_runner.py
@@ -150,7 +150,7 @@ def psfex_interp_runner(
 
     else:
         # Raise error for invalid run mode
-        ValueError("MODE has to be in : [CLASSIC, MULTI-EPOCH, VALIDATION]")
+        raise ValueError("MODE has to be in : [CLASSIC, MULTI-EPOCH, VALIDATION]")
 
     # No return objects
     return None, None

--- a/src/shapepipe/pipeline/file_handler.py
+++ b/src/shapepipe/pipeline/file_handler.py
@@ -792,7 +792,7 @@ class FileHandler(object):
 
         """
         if not isinstance(match_pattern, str):
-            TypeError("Match pattern must be a string.")
+            raise TypeError("Match pattern must be a string.")
 
         chars = [char for char in match_pattern if not char.isalnum()]
         split_pattern = "|".join(chars).replace(".", r"\.")

--- a/src/shapepipe/pipeline/file_io.py
+++ b/src/shapepipe/pipeline/file_io.py
@@ -1389,7 +1389,7 @@ class FITSCatalogue(BaseCatalogue):
             )
 
         if type(col_data) != np.ndarray:
-            TypeError("col_data must be a numpy.ndarray")
+            raise TypeError("col_data must be a numpy.ndarray")
 
         if hdu_no is None:
             hdu_no = self.hdu_no


### PR DESCRIPTION
## Summary

Fixes #785: in `psfex_interp_runner.py`, the guard for an unrecognized `MODE` **constructed** a `ValueError` but never `raise`d it. A typo'd `MODE` skipped all branches, the runner returned `(None, None)`, and the pipeline recorded success while producing no interpolated PSF catalogue — failing only downstream, or not at all.

Adds the missing `raise`, then extends the fix to every other constructed-but-unraised exception found by grepping `src/`:

| File | Guard |
|------|-------|
| `modules/psfex_interp_runner.py` | invalid `MODE` (#785) |
| `modules/mccd_interp_runner.py` | invalid `MODE` — two sites (`VALIDATION` branch + final `else`) |
| `modules/mask_package/mask.py` | invalid mask type |
| `pipeline/file_handler.py` | non-`str` match pattern (docstring already advertises `TypeError`) |
| `pipeline/file_io.py` | non-`ndarray` `col_data` |

All five were the same latent bug: an error path that constructs an exception, discards it, and falls through.

## On Martin's question — is `VALIDATION` ever used?

Yes. `psfex_interp` `VALIDATION` is a live mode: active example configs set `MODE = VALIDATION` (`config_exp_psfex.ini`, `config_exp_Pi.ini`) and it dispatches to the real `PSFExInterpolator.process_validation`. It is not a dead branch, so it stays in the error message. (Note the `mccd_interp_runner` `VALIDATION` branch is different — it exists only to redirect users to the dedicated MCCD validation runner, and now raises as intended.)

## Provenance

Pre-existing on `develop` (predates #741); surfaced by the final integrated review of the ngmix v2.0 diff.

🤖 Generated with Claude Code

— Claude (Opus) on behalf of Cail