### PR TITLE
felt: sync outcome/tempered updates from prior sessions

### DIFF
--- a/.felt/fabian-coord-bug/fabian-coord-bug.md
+++ b/.felt/fabian-coord-bug/fabian-coord-bug.md
@@ -7,5 +7,6 @@ tags:
     - collaboration
     - future
 created-at: 2026-04-27T11:26:52.878118978+02:00
-outcome: 'Fabian: 1-line fix in shapepipe needs porting; first need him to put image-sim code/configs on github so it''s testable. Beg if necessary.'
+updated-at: 2026-06-30T10:10:39.663019273+02:00
+outcome: 'Image-sim code is now on GitHub — published to branch galaxy_pos-unions on UNIONS-WL/MultiBand_ImSim and tracked by [[science/unions/image-sims-to-github]] (tracking issue #1). Remaining: port Fabian''s 1-line shapepipe coord-propagation fix once the sims are runnable/testable there (a sub-issue under the tracker).'
 ---

--- a/.felt/review-ngmix-v2-pr740/review-ngmix-v2-pr740.md
+++ b/.felt/review-ngmix-v2-pr740/review-ngmix-v2-pr740.md
@@ -18,6 +18,7 @@ shuttle:
     host: candide
     project_dir: /automnt/n17data/cdaley/unions/shapepipe
     agent: claude-opus
+tempered: true
 ---
 
 # Review + work: ngmix v2.0 (PR #740)

--- a/.felt/shapepipe/ngmix-size-columns/ngmix-size-columns.md
+++ b/.felt/shapepipe/ngmix-size-columns/ngmix-size-columns.md
@@ -7,11 +7,14 @@ tags:
     - shapepipe
     - ngmix
 created-at: 2026-06-05T22:30:50.004535516+02:00
-outcome: 'Delivered end-to-end and FULLY MERGED 2026-06-11: cs_util#65-67 (v0.2.1 on PyPI with cs_util.size), shapepipe#743 (honest r50, merged into ngmix_v2.0), shear_psf_leakage#23 (cs-util cap relaxation), sp_validation#198 (T_to_fwhm fix + galaxy smoke test) — the whole dependency chain closed in one night. The T_to_fwhm fix moves α(size) leakage results; regenerate where it mattered. Deferred (stated in #743): wiring honest r50/r50psf into make_cat so paper-convention r_h reaches the science catalogue.'
+updated-at: 2026-07-09T10:49:05.511810013+02:00
+closed-at: 2026-06-30T09:46:25.557072068Z
+outcome: 'Delivered end-to-end and FULLY MERGED 2026-06-11: cs_util#65-67 (v0.2.1 on PyPI with cs_util.size), shapepipe#743 (honest r50, merged into ngmix_v2.0), shear_psf_leakage#23 (cs-util cap relaxation), sp_validation#198 (T_to_fwhm fix + galaxy smoke test) — the whole dependency chain closed in one night. The T_to_fwhm fix moves α(size) leakage results; regenerate where it mattered. SUPERSEDED 2026-07-09: the deferred ''wire r50 into make_cat'' item is now moot — #761''s column-grammar decision (2026-06-30) settled on T as the ONLY stored size column (''T everywhere — nothing hand-coded''), with r50/FWHM/sigma as on-demand cs_util.size conversions, never stored. Confirmed zero r50/r_h references anywhere in src/. ShapePipe v2''s ellipticity-sensitive ngmix T (= Ixx+Iyy, matches DES convention) is the catalog''s one size quantity; no further make_cat work needed here.'
 shuttle:
     kind: oneshot
     host: candide
     agent: claude-fable
+tempered: true
 ---
 
 # ngmix size columns: honest r50 + cs_util converter web

--- a/.felt/shapepipe/ngmix-weights-ivar/ngmix-weights-ivar.md
+++ b/.felt/shapepipe/ngmix-weights-ivar/ngmix-weights-ivar.md
@@ -14,6 +14,7 @@ shuttle:
     kind: oneshot
     host: candide
     agent: codex
+tempered: true
 ---
 
 # ngmix weight map: fix v2.0 regressions + inverse-variance (#604)


### PR DESCRIPTION
Doc-only: carries forward pending felt bookkeeping from prior sessions that
had accumulated as uncommitted working-tree edits — image-sim tracking-issue
link on fabian-coord-bug, `tempered: true` flags on three closed fibers, and
the ngmix-size-columns superseded note (T-only column grammar, #761).

No code changes.

— Claude on behalf of Cail