### PR TITLE
deps: advance cs_util develop pin in uv.lock (ff8fa2b → bedcdbf)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -654,8 +654,8 @@ wheels = [
 
 [[package]]
 name = "cs-util"
-version = "0.2.1"
-source = { git = "https://github.com/CosmoStat/cs_util?branch=develop#ff8fa2b2168737353ac867cc21a8e95be082f17b" }
+version = "0.2.2"
+source = { git = "https://github.com/CosmoStat/cs_util?branch=develop#bedcdbf50ac57fc4d0b72a62b251373cd1807824" }
 dependencies = [
     { name = "astropy", marker = "sys_platform == 'linux'" },
     { name = "camb", marker = "sys_platform == 'linux'" },


### PR DESCRIPTION
Closes #806.

Advances the pinned cs_util **develop-branch** commit in `uv.lock` to develop's current tip: `ff8fa2b` → `bedcdbf`. `pyproject.toml` already sources cs_util from `branch = "develop"`; this just moves the frozen lock forward to the latest commit on it, so the published image ships current cs_util (with `cs_util.size`) instead of a months-old develop snapshot. Downstream sp_validation then inherits it from the base image.

(The `0.2.1 → 0.2.2` in the diff is just the `setuptools_scm`-derived version string of those two develop commits — not a release bump.)

Scoped `uv lock --upgrade-package cs-util`; lock-only, 2 lines (commit SHA + derived version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vtw1qcgTrQ6YuMvxwYzNup