### PR TITLE
Update contributors list

### DIFF
--- a/docs/source/contributors.md
+++ b/docs/source/contributors.md
@@ -41,12 +41,15 @@ Martin Kilbinger
 - [Axel Guinot](https://github.com/aguinot) : Primary module developer, validation, performance and debugging
 - [Martin Kilbinger](https://github.com/martinkilbinger) : Scientific lead, module developer and debugging
 
-## Principal Contributors
+## Contributors
 
 - [Lucie Baumont](https://github.com/lbaumo) : Testing
 - [Jérôme Bonnin](https://github.com/jerome-bonnin) : PSF module developer
+- [Cail Daley](https://www.cosmostat.org/people/cail-daley) : Container development
+- [Fabian Hervas Peters](https://www.cosmostat.org/people/former-members/fabian-hervas-peters) : Simulations, validation
 - Marc Gentile : File IO, initial architecture
-- Xavier Jimenez : External catalogue matching module developer
+- [Mike Hudson](https://uwaterloo.ca/physics-astronomy/profile/mjhudson) : Further contributors
+- Xavier Jimenez : External catalogue matching
 - [François Lanusse](https://github.com/eiffl) : Further contributors
 - [Tobias Liaudat](https://github.com/tobias-liaudat) : PSF module developer and validation
 - [Austin Peel](https://github.com/austinpeel) : Validation

--- a/src/shapepipe/info.py
+++ b/src/shapepipe/info.py
@@ -69,11 +69,8 @@ def shapepipe_logo(colour=False):
              Martin Kilbinger <martin.kilbinger@cea.fr>
 
     Main Contributors:
-             Tobias Liaudat
-             Morgan Schmitz
-             Andre Zamorano Vitorelli
-             Francois Lanusse
-             Xavier Jimenez
+            Cail Daley
+            Fabian Hervas Peters
 
     Version: {}
 


### PR DESCRIPTION
Updates `contributors.md` (adds Cail Daley, Fabian Hervas Peters, Mike Hudson; renames "Principal Contributors" → "Contributors") and the `info.py` logo contributor list.

Split off from #704, which combined this with the unrelated coverage-mask work (now living in #797). Changes are Martin's, lifted verbatim onto a clean branch off `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJEQwNRApVAQnt53fkyXLZ