### PR TITLE
chore: pin deps so Renovate honors minimumReleaseAge (reliable automerge)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  "//": "Repo-level overrides layered on top of the Mend-hosted defaults (grouping, automerge, schedule stay as configured there). Two knobs, both aimed at making dependency automerge reliable without hand-nudging.",
+  "//": "Repo-level overrides layered on the Mend-hosted defaults (grouping, automerge, schedule stay as configured there). Goal: KEEP the supply-chain release-age delay AND make dependency automerge reliable.",
 
-  "//rangeStrategy": "pyproject.toml carries FLOOR constraints (major-version signals); uv.lock is the real pin. For minor/patch updates, bump the lock and leave the pyproject floors alone. (Non-lock ecosystems — Dockerfile, github-actions — fall back to 'replace' automatically.)",
-  "rangeStrategy": "update-lockfile",
+  "//rangeStrategy": "Pin registry deps to exact versions. This is the only way Renovate can honor minimumReleaseAge with uv: given floor ranges (>=), `uv lock` resolves the floor to the NEWEST in-range release — which may still be too fresh — and Renovate cannot pin uv to an exact aged version (renovatebot/renovate#41624), so it fails the artifact update instead of waiting (this stalled #816). Pinning writes the exact aged version into pyproject.toml, so uv can't overshoot and the age gate is respected. shapepipe is deployed as a container and is not published to PyPI (an application, not a library with downstream installers), so pinning is the appropriate, standard choice; the abstract-floors design in CLAUDE.md targets libraries, which this isn't. Renovate opens a one-time 'Pin dependencies' PR. NOTE: this gates DIRECT deps only — transitive deps in uv.lock still float to latest via lockFileMaintenance.",
+  "rangeStrategy": "pin",
 
-  "//minimumReleaseAge": "Disable the minimum-release-age gate. With floor ranges, Renovate targets an aged version but `uv lock` resolves the floor to the NEWEST in-range release — which may still be inside the age window — and Renovate cannot pin uv to an exact version (renovatebot/renovate#41624). The result is a failed artifact update that stalls automerge (this blocked #816). ShapePipe CI (full test suite + the example pipeline, on every PR) is the real safety gate for a dependency bump, so gate on CI, not on a waiting period.",
-  "minimumReleaseAge": "0 days"
+  "//internalChecksFilter": "Only ever act on versions that have passed the internal checks (release age) — never pin to a too-fresh release.",
+  "internalChecksFilter": "strict",
+
+  "//minimumReleaseAge": "Supply-chain delay: don't adopt a release until it is this old, so a hijacked-but-legitimate package (compromised maintainer / malicious release) has time to be detected and yanked before it auto-merges. Set explicitly here (owned in git, not an invisible Mend toggle). Tune up for a longer detection window.",
+  "minimumReleaseAge": "3 days"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "//": "Repo-level overrides layered on top of the Mend-hosted defaults (grouping, automerge, schedule stay as configured there). Two knobs, both aimed at making dependency automerge reliable without hand-nudging.",
+
+  "//rangeStrategy": "pyproject.toml carries FLOOR constraints (major-version signals); uv.lock is the real pin. For minor/patch updates, bump the lock and leave the pyproject floors alone. (Non-lock ecosystems — Dockerfile, github-actions — fall back to 'replace' automatically.)",
+  "rangeStrategy": "update-lockfile",
+
+  "//minimumReleaseAge": "Disable the minimum-release-age gate. With floor ranges, Renovate targets an aged version but `uv lock` resolves the floor to the NEWEST in-range release — which may still be inside the age window — and Renovate cannot pin uv to an exact version (renovatebot/renovate#41624). The result is a failed artifact update that stalls automerge (this blocked #816). ShapePipe CI (full test suite + the example pipeline, on every PR) is the real safety gate for a dependency bump, so gate on CI, not on a waiting period.",
+  "minimumReleaseAge": "0 days"
+}


### PR DESCRIPTION
## Why

ShapePipe has **no repo Renovate config** — everything comes from Mend defaults, and dependency automerge is unreliable: grouped update PRs (#816) stall on a `renovate/artifacts` "Artifact file update failure."

**The failure is a supply-chain-gate mechanics problem, not a real conflict.** `pyproject.toml` uses *floor* constraints (`tqdm>=4.68.1`). Renovate wants to move to an *aged* version (tqdm 4.68.3, past the minimum-release-age window), but updates the lock via `uv lock`, which resolves the floor to the *newest* in-range release (4.68.4) — still too fresh. Renovate can't tell uv to pin an exact version ([renovatebot/renovate#41624](https://github.com/renovatebot/renovate/issues/41624)), so it **fails instead of waiting**.

## Keep the release-age gate — it's the point

`minimumReleaseAge` is a **supply-chain defense**: a hijacked-but-legitimate package (compromised maintainer, malicious release — the common attack now) gets a detection window before it auto-merges into the pipeline. We want to *keep* it, not drop it. The task is making Renovate actually honor it.

## The fix

A `renovate.json` layered over the Mend defaults:

- **`rangeStrategy: "pin"`** — the one way Renovate can honor `minimumReleaseAge` with uv. It writes the exact *aged* version into `pyproject.toml`, so `uv lock` can't overshoot to a too-fresh release. Renovate's own recommendation for applications.
- **`internalChecksFilter: "strict"`** — only ever act on versions that have passed the age gate.
- **`minimumReleaseAge: "3 days"`** — the supply-chain delay, now owned in git (not an invisible Mend toggle) and tunable. Bump it for a longer detection window.

## Trade-offs to weigh (your + Martin's call)

- **pyproject deps become exact `==` pins.** This departs from the CLAUDE.md "abstract floors / uv.lock is the pin" design. But that design's rationale is *downstream flexibility for library installers* — and **shapepipe isn't a library**: it's not on PyPI, it ships as a container built from `uv.lock`. For an application, pinning is the standard, secure choice. Renovate will open a one-time **"Pin dependencies"** PR to do the rewrite.
- **Direct deps only.** `minimumReleaseAge` gates the deps Renovate sees (direct, in pyproject). Transitive deps in `uv.lock` still float to latest via `lockFileMaintenance` — an existing gap, not made worse here.
- **Watch the pin PR for the git-sourced deps** (`ngmix`, `cs_util` via `[tool.uv.sources]`) — pinning should leave their git refs alone, but worth a glance on the first run.

If you'd rather keep abstract floors and accept that automerge needs an occasional nudge (the failures self-heal as versions age), say so and I'll pare this back to just documenting that.

## Note

Config takes effect once merged to `develop` and Renovate re-runs; a malformed config surfaces as a Renovate comment, not a CI failure here. Validated as well-formed JSON against the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)