### PR TITLE
fix(setools): guard _mode against degenerate zoom window

### DIFF
--- a/src/shapepipe/pipeline/str_handler.py
+++ b/src/shapepipe/pipeline/str_handler.py
@@ -290,6 +290,19 @@ class StrInterpreter(object):
 
         iteration = 0
         while diff > eps:
+            if len(data) == 0:
+                raise ValueError(
+                    "Mode computation failed: zoom window emptied out"
+                    f" after {iteration} iterations"
+                )
+            if np.ptp(data) <= eps:
+                # The zoom window has degenerated: the remaining values span
+                # less than the requested accuracy (e.g. near-identical
+                # float32 values, for which np.histogram cannot construct
+                # distinct bin edges). The surviving sample localises the
+                # mode to within eps, so return its median.
+                return np.median(data)
+
             hist = np.histogram(data, bins)
             if hist[0].max() == 1:
                 break
@@ -306,7 +319,11 @@ class StrInterpreter(object):
             iteration += 1
 
         if iteration == iter_max:
-            raise ValueError("Mode computation failed")
+            raise ValueError(
+                f"Mode computation did not converge after {iter_max} "
+                f"iterations ({len(data)} objects left in zoom window, "
+                f"value range [{data.min()}, {data.max()}])"
+            )
         else:
             mode = (b_min + b_max) / 2.0
             return mode


### PR DESCRIPTION
## Problem
During the Nibi test run in #808, several single-exposure CCDs crashed in the SEtools star-selection step with `ValueError: Too many bins for data range. Cannot create 70 finite-sized bins.` The affected CCDs have FWHM distributions where the stellar-locus zoom window collapses onto a cluster of near-identical float32 values, so `np.histogram` is asked to build 70 bins over an (effectively) zero-width range.

## Root cause
`SETools._mode` iteratively zooms into the histogram peak. When the zoomed data are degenerate (all values equal to float32 precision), the bin-edge computation produces a zero/denormal bin width and numpy raises before a mode can be returned.

## Fix
Guard the zoom loop in `shapepipe/modules/setools_package/str_handler.py`: when the zoom window becomes degenerate, return the (single) value directly instead of histogramming it. +18/-1 lines, no behaviour change for healthy inputs.

## Evidence / testing
- Standalone repro in the runtime container: a degenerate near-identical-float32 cluster returns mode 4.0 on this branch; the identical input against `origin/develop`'s `str_handler` raises the 70-bins `ValueError`.
- Healthy control input returns 4.0798, bit-for-bit identical to develop.
- Full setools rerun in the container on a previously-crashing CCD completes and selects 56 stars.

Found during the Nibi test run in #808.

— Claude (Fable) on behalf of Cail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
