### PR TITLE
fix(mask): exclude NaN GSC magnitudes from halo/spike mean magnitude

### DIFF
--- a/src/shapepipe/modules/mask_package/mask.py
+++ b/src/shapepipe/modules/mask_package/mask.py
@@ -888,26 +888,25 @@ class Mask(object):
         star_zip = zip(*(stars[k] for k in keys_to_use))
 
         for ra, dec, Fmag, Jmag, Vmag, Nmag, clas in star_zip:
-            mag = 0.0
-            idx = 0.0
-
-            # Compute mean magnitude
-            if Fmag is not None:
-                mag += Fmag
-                idx += 1.0
-            if Jmag is not None:
-                mag += Jmag
-                idx += 1.0
-            if Vmag is not None:
-                mag += Vmag
-                idx += 1.0
-            if Nmag is not None:
-                mag += Nmag
-                idx += 1.0
-            if idx == 0.0:
-                mag = None
+            # Compute mean magnitude over the available (finite) bands.
+            # Missing GSC bands are NaN and must be excluded: a single NaN
+            # would make the mean NaN and silently fail the
+            # ``mag < mag_limit`` test below, leaving bright stars with
+            # incomplete photometry (the ones that most need masking)
+            # unmasked.
+            mags = [
+                band
+                for band in (Fmag, Jmag, Vmag, Nmag)
+                if band is not None and np.isfinite(band)
+            ]
+            if len(mags) > 0:
+                mag = sum(mags) / len(mags)
             else:
-                mag /= idx
+                mag = None
+                self._w_log.info(
+                    f"No finite {types} magnitude for star at ra={ra} "
+                    + f"dec={dec}; object not masked"
+                )
 
             if (
                 ra is not None


### PR DESCRIPTION
## Problem
During the Nibi test run in #808, the mask module produced halo/spike masks that silently omitted some of the brightest objects in the field. The GSC catalogue used to seed halo masks contains entries with NaN magnitudes; these poisoned the mean-magnitude computation used to scale halo sizes, so bright stars near NaN entries were mishandled and dropped from the mask.

## Root cause
`mask.py` computes a mean over GSC magnitudes without excluding NaNs, so any NaN entry propagates and corrupts the halo-magnitude logic.

## Fix
Exclude NaN GSC magnitudes from the halo/spike mean-magnitude computation in `shapepipe/modules/mask_package/mask.py` (+18/-19 lines vs develop).

## Evidence / testing
- On the affected Nibi tile, the halo star count goes from 57 to 118, now including very bright objects in the mag 5.7–9.5 range; all 57 originally-selected halo stars are unchanged.
- End-to-end mask rerun on exposure 2586338-11 completes with the corrected halo set.
- Honesty note: the poster-child "bright object" recovered here is actually the galaxy NGC 5949, shredded by GSC into a Class-0 entry — the fix is still correct (NaN magnitudes must not poison the mean), but that particular object is a catalogue artefact rather than a bright star.

Found during the Nibi test run in #808.

— Claude (Fable) on behalf of Cail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Related: #662** — bright stars with missing GSC bands silently received *no* halo mask at all, which presents exactly as the under-masked bright stars reported there (on the test CCD, the halo-star count went 57 → 118 with this fix, and the recovered objects are the brightest in the field, mag 5.7–9.5). Worth re-assessing #662 once this is in; any residual contamination would then point at halo *radius* scaling rather than missing masks.
