### PR TITLE
fix: merge_headers multi-tile merge, strict env-var expansion, stale example run names

### DIFF
--- a/example/cfis/config_exp_Ma_onthefly.ini
+++ b/example/cfis/config_exp_Ma_onthefly.ini
@@ -76,4 +76,4 @@ USE_EXT_STAR = False
 PREFIX = pipeline
 
 # Path to check for existing output mask files
-CHECK_EXISTING_DIR = $SP_RUN/output/run_sp_Ma_exp/mask_runner/output
+CHECK_EXISTING_DIR = $SP_RUN/output/run_sp_exp_Ma/mask_runner/output

--- a/example/cfis/config_exp_psfex.ini
+++ b/example/cfis/config_exp_psfex.ini
@@ -58,7 +58,7 @@ TIMEOUT = 96:00:00
 [SEXTRACTOR_RUNNER]
 
 # Input from two modules
-#INPUT_DIR = last:split_exp_runner, run_sp_Ma_exp:mask_runner
+#INPUT_DIR = last:split_exp_runner, run_sp_exp_Ma:mask_runner
 INPUT_DIR = last:split_exp_runner, last:mask_runner
 
 # Read pipeline flag files created by mask module

--- a/example/cfis/config_tile_Ma_onthefly.ini
+++ b/example/cfis/config_tile_Ma_onthefly.ini
@@ -56,7 +56,7 @@ TIMEOUT = 96:00:00
 [MASK_RUNNER]
 
 # Input directory, containing input files, single string or list of names
-INPUT_DIR = run_sp_Git:get_images_runner, last:uncompress_fits_runner
+INPUT_DIR = run_sp_tile_Git:get_images_runner, last:uncompress_fits_runner
 
 # NUMBERING_SCHEME (optional) string with numbering pattern for input files
 NUMBERING_SCHEME = -000-000

--- a/example/cfis/config_tile_Sx.ini
+++ b/example/cfis/config_tile_Sx.ini
@@ -55,7 +55,7 @@ TIMEOUT = 96:00:00
 
 [SEXTRACTOR_RUNNER]
 
-INPUT_DIR = run_sp_Git:get_images_runner, last:uncompress_fits_runner, run_sp_Ma_tile:mask_runner, run_sp_tile_Mh_exp:merge_headers_runner
+INPUT_DIR = run_sp_tile_Git:get_images_runner, last:uncompress_fits_runner, run_sp_tile_Ma:mask_runner, run_sp_tile_Mh_exp:merge_headers_runner
 
 FILE_PATTERN = CFIS_image, CFIS_weight, pipeline_flag, log_exp_headers
 

--- a/example/cfis/config_tile_Sx_nomask.ini
+++ b/example/cfis/config_tile_Sx_nomask.ini
@@ -55,7 +55,7 @@ TIMEOUT = 96:00:00
 
 [SEXTRACTOR_RUNNER]
 
-INPUT_DIR = run_sp_Git:get_images_runner, last:uncompress_fits_runner, run_sp_tile_Mh_exp:merge_headers_runner
+INPUT_DIR = run_sp_tile_Git:get_images_runner, last:uncompress_fits_runner, run_sp_tile_Mh_exp:merge_headers_runner
 
 FILE_PATTERN = CFIS_image, CFIS_weight, log_exp_headers
 

--- a/src/shapepipe/modules/merge_headers_runner.py
+++ b/src/shapepipe/modules/merge_headers_runner.py
@@ -38,25 +38,29 @@ def merge_headers_runner(
         # Tile-level mode: input is an exp_numbers txt file; collect header
         # files from each per-exposure work directory via get_exp_output_files.
         exp_base_dir = config.getexpanded(module_config_sec, "EXP_BASE_DIR")
-        exp_numbers_file = input_file_list[0][0]
-        w_log.info(
-            f"Tile-level merge: collecting headers from {exp_base_dir} "
-            f"using {exp_numbers_file}"
-        )
-        headers_file_list = get_exp_output_files(
-            exp_base_dir,
-            exp_numbers_file,
-            "split_exp_runner",
-            "headers",
-            ".npy",
-            w_log=w_log,
-        )
-        # Extract tile number from the exp_numbers filename, e.g.
-        # "exp_numbers-284.272-1.000.txt" -> "-284.272-1.000"
-        base = os.path.splitext(os.path.basename(exp_numbers_file))[0]
-        tile_number = re.sub(r"^exp_numbers", "", base)
-        merge_headers(headers_file_list, output_dir, tile_number)
-        w_log.info(f"Merged {len(headers_file_list)} exposure header files")
+        # In serial mode several tiles' exp_numbers files can arrive in a
+        # single call; merge each tile into its own per-tile sqlite file.
+        for exp_numbers_file in (item[0] for item in input_file_list):
+            w_log.info(
+                f"Tile-level merge: collecting headers from {exp_base_dir} "
+                f"using {exp_numbers_file}"
+            )
+            headers_file_list = get_exp_output_files(
+                exp_base_dir,
+                exp_numbers_file,
+                "split_exp_runner",
+                "headers",
+                ".npy",
+                w_log=w_log,
+            )
+            # Extract tile number from the exp_numbers filename, e.g.
+            # "exp_numbers-284.272-1.000.txt" -> "-284.272-1.000"
+            base = os.path.splitext(os.path.basename(exp_numbers_file))[0]
+            tile_number = re.sub(r"^exp_numbers", "", base)
+            merge_headers(headers_file_list, output_dir, tile_number)
+            w_log.info(
+                f"Merged {len(headers_file_list)} exposure header files"
+            )
     else:
         # Per-exposure mode: input_file_list already contains the header files.
         merge_headers(input_file_list, output_dir)

--- a/src/shapepipe/pipeline/config.py
+++ b/src/shapepipe/pipeline/config.py
@@ -7,7 +7,42 @@ This module defines methods for handling the pipeline configuration file.
 """
 
 import os
+import re
 from configparser import ConfigParser
+
+
+def _expandvars_strict(value):
+    """Expand Environment Variables Strictly.
+
+    Expand environment variables in ``value``, raising an error if any
+    referenced variable is unset instead of silently leaving the literal
+    ``$VAR`` string in place.
+
+    Parameters
+    ----------
+    value : str
+        Configuration value possibly containing ``$VAR`` or ``${VAR}``
+        references
+
+    Returns
+    -------
+    str
+        Value with all environment variables expanded
+
+    Raises
+    ------
+    ValueError
+        If a referenced environment variable is not set
+
+    """
+    expanded = os.path.expandvars(value)
+    unset = re.findall(r"\$\{?(\w+)\}?", expanded)
+    if unset:
+        raise ValueError(
+            f"Environment variable(s) {', '.join(sorted(set(unset)))} "
+            + f"referenced in config value '{value}' not set."
+        )
+    return expanded
 
 
 class CustomParser(ConfigParser):
@@ -35,7 +70,7 @@ class CustomParser(ConfigParser):
             Expanded enviroment variables
 
         """
-        return self._get(section, os.path.expandvars, option, **kwargs)
+        return self._get(section, _expandvars_strict, option, **kwargs)
 
     def getlist(self, section, option, delimiter=",", **kwargs):
         """Get List.


### PR DESCRIPTION
Three small quality-of-life fixes for failure modes that cost real debugging time during the Nibi test run in #808.

## 1. `merge_headers`: merge all tiles in serial tile-level mode
**Problem:** in serial tile-level runs, `merge_headers` only merged the first tile's header sqlite, silently dropping the rest — downstream modules then failed mysteriously on missing exposures.
**Fix:** loop over all tile inputs. On the Nibi run this takes the merged output from 1 to 10 sqlite files, matching the 10 tiles processed.

## 2. `config.py`: raise a clear error on unset env vars
**Problem:** `getexpanded` passed literal `$VAR` strings through when the environment variable was unset, producing paths like `$SP_RUN/output` that fail much later with confusing file-not-found errors.
**Fix:** new `_expandvars_strict` — `getexpanded` now raises `ValueError` naming every unset variable at config-read time.
**Tested in the runtime container:** with `SP_TEST_VAR` set, expansion yields `/scratch/foo/output`; unset, it raises `Environment variable(s) SP_TEST_VAR referenced in config value '$SP_TEST_VAR/output' not set.`

## 3. `example/cfis`: correct stale run-name references
**Problem:** several example configs reference run names that no sibling config produces (`run_sp_Git`, `run_sp_Ma_tile`, `run_sp_Ma_exp`), so following the examples verbatim fails.
**Fix:** updated to the names actually produced (`run_sp_tile_Git`, `run_sp_tile_Ma`, `run_sp_exp_Ma`). A grep audit confirms zero remaining run-name references unproduced by siblings (`run_sp_combined_flag` in `config_Rc.ini` is deliberately kept — it is a user-created directory documented in `docs/source/random_cat.md`).

Found during the Nibi test run in #808.

— Claude (Fable) on behalf of Cail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
