### PR TITLE
fix(mask): footprint-based NGC/Messier overlap test

### DIFF
--- a/src/shapepipe/modules/mask_package/mask.py
+++ b/src/shapepipe/modules/mask_package/mask.py
@@ -595,8 +595,8 @@ class Mask(object):
         unit_size_X = file_io.get_unit_from_fits_header(header, "size_X")
         unit_size_Y = file_io.get_unit_from_fits_header(header, "size_Y")
 
-        # Loop through all deep-sky objects and check whether any corner is
-        # closer than the object's radius
+        # Loop through all deep-sky objects and check whether the object's
+        # disc overlaps the image footprint
         indices = []
         size_max_deg = []
         for idx, m_obj in enumerate(m_cat):
@@ -610,9 +610,14 @@ class Mask(object):
             r_deg = r.to(units.degree)
             size_max_deg.append(r_deg)
 
-            # Add index to list if distance between DSO and any image corner
-            # is closer than DSO size
-            if np.any(self._corners_sc.separation(m_sc[idx]) < r_deg):
+            # Add index to list if the DSO disc overlaps the image:
+            # distance between DSO centre and image centre smaller than
+            # DSO radius plus image half-diagonal. (Testing only the image
+            # corners against the DSO radius, as done previously, misses
+            # objects that are smaller than the image and lie away from
+            # the corners.)
+            dist = self._fieldcenter["wcs"].separation(m_sc[idx])
+            if dist < r_deg + self._img_radius * units.arcmin:
                 indices.append(idx)
 
         self._w_log.info(


### PR DESCRIPTION

## Problem

`mask_dso` selects an NGC/Messier object only if an image **corner** lies within the object's radius of its centre. Objects smaller than the CCD that sit mid-image — i.e. most catalogued galaxies — never satisfy this and are silently skipped. On CFIS P3 exposure 2586338 CCD 11, NGC 5949 sits 3′ from the CCD centre, is present in `ngc_cat.fits`, and the log reads `Found 0 NGC objects overlapping with image`.

## Root cause

```python
if np.any(self._corners_sc.separation(m_sc[idx]) < r_deg):
```
tests corner proximity, which is an overlap test only for objects larger than the image.

## Fix

Footprint overlap using the existing `_fieldcenter` / `_img_radius`: select when the object centre is within (object radius + image half-diagonal) of the image centre. Catches objects anywhere on or overlapping the CCD, scales with the per-object catalogue size, and strictly contains the old criterion (corner within `r` ⇒ centre within `r` + half-diagonal), so nothing previously selected is lost.

## Evidence

- Unit (2586338-11 WCS × full `ngc_cat.fits`, 11,454 objects): old criterion 0 → new 1; the selected object is NGC 5949 (sep 3.0′, inside footprint, size 2.2′×1.0′). Nearest non-selected object is 151′ away.
- End-to-end `mask_runner` rerun on 2586338-11: `Found 1 NGC objects overlapping with image`; NGC-bit pixels 0 → 930,704, mask centred on the galaxy. Before/after figure:

![NGC 5949 before/after](https://gist.githubusercontent.com/cailmdaley/20b1c4a9882d8064efd40cb01386d6c4/raw/2586338-11-ngc5949-beforeafter.png)
- Control (DSO-free CCD 2254867-10): flag map bit-for-bit identical to develop.

Found during the Nibi test run in #808 — this completes that comment's NGC 5949 story (the bright glow there is the galaxy; its GSC counterpart 0.3′ away is likely its nucleus) and complements #824/#662.

— Claude (Fable) on behalf of Cail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
