### PR TITLE
Selectable metacal reconvolution kernel + azgauss; bump ngmix v2.4.1

### DIFF
--- a/example/cfis/config_tile_Ng_template.ini
+++ b/example/cfis/config_tile_Ng_template.ini
@@ -83,5 +83,13 @@ PIXEL_SCALE = 0.186
 # noisy for stars and flagged as incorrect — see #767).
 CENTROID_SOURCE = wcs
 
+# METACAL_PSF (optional): the metacal reconvolution-kernel scheme
+# (metacal_pars['psf']). "fitgauss" (default) fits a Gaussian to the PSF and
+# rounds it; "gauss" reconvolves with a fixed round Gaussian sized from the
+# PSF; "dilate" dilates the original PSF; "azgauss" (ngmix >= 2.4.1) is a
+# noise-robust variant of "gauss". Sets the round PSF metacal reconvolves
+# with after shearing, so it moves the metacal response.
+METACAL_PSF = fitgauss
+
 ID_OBJ_MIN = X
 ID_OBJ_MAX = X

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ canfar_monitor_log  = "shapepipe.canfar_run:run_monitor_log"
 environments = ["sys_platform == 'linux'"]
 
 [tool.uv.sources]
-ngmix = { git = "https://github.com/esheldon/ngmix", tag = "v2.4.0" }
+ngmix = { git = "https://github.com/esheldon/ngmix", tag = "v2.4.1" }
 # Track cs_util's develop branch (a git ref, not a pinned release) so new
 # cs_util.size / cs_util.shape helpers are available without shipping a release
 # and rebuilding the image each time. shapepipe's column grammar sources size

--- a/src/shapepipe/modules/ngmix_package/ngmix.py
+++ b/src/shapepipe/modules/ngmix_package/ngmix.py
@@ -294,6 +294,7 @@ class Ngmix(object):
         id_obj_min=-1,
         id_obj_max=-1,
         centroid_source="hsm",
+        metacal_psf="fitgauss",
     ):
 
         if len(input_file_list) not in {6, 7}:
@@ -325,6 +326,7 @@ class Ngmix(object):
         self._id_obj_min = id_obj_min
         self._id_obj_max = id_obj_max
         self._centroid_source = centroid_source
+        self._metacal_psf = metacal_psf
 
         self._w_log = w_log
 
@@ -700,6 +702,7 @@ class Ngmix(object):
                     flux_guess,
                     self._rng,
                     centroid_source=self._centroid_source,
+                    metacal_psf=self._metacal_psf,
                 )
             except Exception as ee:
                 self._w_log.info(
@@ -1337,7 +1340,9 @@ def make_runners(prior, flux_guess, rng):
     )
 
 
-def do_ngmix_metacal(stamp, prior, flux_guess, rng, centroid_source="hsm"):
+def do_ngmix_metacal(
+    stamp, prior, flux_guess, rng, centroid_source="hsm", metacal_psf="fitgauss"
+):
     """Do Ngmix Metacal.
 
     Performs metacalibration on a single multi-epoch object and returns the
@@ -1359,6 +1364,17 @@ def do_ngmix_metacal(stamp, prior, flux_guess, rng, centroid_source="hsm"):
         adaptive-moment centroid); ``"wcs"`` uses the catalog sky position
         projected through the WCS — see that function for the star-vs-galaxy
         rationale.
+    metacal_psf : {"fitgauss", "gauss", "dilate", "azgauss"}, optional
+        The metacal reconvolution-kernel scheme passed to ngmix as
+        ``metacal_pars['psf']``. The default ``"fitgauss"`` fits a Gaussian to
+        the PSF and rounds it (``MetacalFitGaussPSF``); ``"gauss"`` reconvolves
+        with a fixed round Gaussian sized from the PSF (``MetacalGaussPSF``);
+        ``"dilate"`` dilates the original PSF; ``"azgauss"`` (ngmix >= 2.4.1) is
+        a noise-robust variant of ``"gauss"``. This kernel is a SEPARATE object
+        from the PSF-model fit (the ``psf_runner`` above) — it only sets the
+        round PSF that metacal reconvolves with after shearing, so it moves the
+        metacal *response* (and therefore the recovered shear) but never reaches
+        the deconvolution, which is by the PSF image.
 
     Returns
     -------
@@ -1407,7 +1423,7 @@ def do_ngmix_metacal(stamp, prior, flux_guess, rng, centroid_source="hsm"):
     metacal_pars = {
         'types': ['noshear', '1p', '1m', '2p', '2m'],
         'step': 0.01,
-        'psf': 'fitgauss',
+        'psf': metacal_psf,
         'fixnoise': True,
         'use_noise_image': True,
     }

--- a/src/shapepipe/modules/ngmix_runner.py
+++ b/src/shapepipe/modules/ngmix_runner.py
@@ -88,6 +88,15 @@ def ngmix_runner(
     else:
         centroid_source = "wcs"
 
+    # Metacal reconvolution-kernel scheme (metacal_pars['psf']): "fitgauss"
+    # (default; fit a Gaussian to the PSF and round it), "gauss" (fixed round
+    # Gaussian sized from the PSF), "dilate" (dilate the original PSF), or
+    # "azgauss" (ngmix >= 2.4.1; noise-robust variant of "gauss").
+    if config.has_option(module_config_sec, "METACAL_PSF"):
+        metacal_psf = config.get(module_config_sec, "METACAL_PSF")
+    else:
+        metacal_psf = "fitgauss"
+
     # Initialise class instance
     ngmix_inst = Ngmix(
         input_file_list,
@@ -101,6 +110,7 @@ def ngmix_runner(
         id_obj_min=id_obj_min,
         id_obj_max=id_obj_max,
         centroid_source=centroid_source,
+        metacal_psf=metacal_psf,
     )
 
     # Process ngmix shape measurement and metacalibration

--- a/tests/module/test_ngmix.py
+++ b/tests/module/test_ngmix.py
@@ -136,6 +136,77 @@ def test_metacal_is_reproducible_with_fixed_seed():
     npt.assert_array_equal(_metacal_noshear_g(42), _metacal_noshear_g(42))
 
 
+def _metacal_noshear_g_with_psf(seed, **kwargs):
+    """``_metacal_noshear_g`` forwarding extra kwargs to ``do_ngmix_metacal``.
+
+    Used to exercise the ``metacal_psf`` reconvolution-kernel knob while holding
+    the simulated data and seed fixed.
+    """
+    from shapepipe.modules.ngmix_package.ngmix import (
+        Postage_stamp,
+        do_ngmix_metacal,
+        get_prior,
+    )
+    from shapepipe.testing.simulate import make_data
+
+    rng = np.random.RandomState(seed)
+    prior = get_prior(0.1857, rng)
+    gals, psfs, _, weights, flags, jacobs = make_data(
+        rng=np.random.RandomState(123),
+        shear=(0.02, 0.0),
+        noise=1e-4,
+        n_epochs=2,
+        img_size=51,
+    )
+    stamp = Postage_stamp(bkg_sub=False, megacam_flip=False)
+    stamp.gals, stamp.psfs, stamp.weights, stamp.flags, stamp.jacobs = (
+        gals,
+        psfs,
+        weights,
+        flags,
+        jacobs,
+    )
+    res, _, _ = do_ngmix_metacal(stamp, prior, 1.0, rng, **kwargs)
+    return np.asarray(res["noshear"]["g"])
+
+
+def test_metacal_psf_default_is_fitgauss_byte_for_byte():
+    """The ``metacal_psf`` knob defaults to the historical hardcode.
+
+    ``do_ngmix_metacal`` set ``metacal_pars['psf'] = 'fitgauss'`` unconditionally
+    before the knob existed; passing it explicitly must reproduce the no-kwarg
+    result bit-for-bit, so the parameterization is purely additive.
+    """
+    npt.assert_array_equal(
+        _metacal_noshear_g_with_psf(42),
+        _metacal_noshear_g_with_psf(42, metacal_psf="fitgauss"),
+    )
+
+
+def test_metacal_psf_gauss_is_a_live_alternative():
+    """``gauss`` (fixed round Gaussian) is a valid alternative kernel.
+
+    It must run to a finite shear and differ from ``fitgauss`` — the knob is
+    genuinely wired through to ngmix's metacal, not a no-op.
+    """
+    g_fit = _metacal_noshear_g_with_psf(42, metacal_psf="fitgauss")
+    g_gauss = _metacal_noshear_g_with_psf(42, metacal_psf="gauss")
+    assert np.all(np.isfinite(g_gauss))
+    assert not np.array_equal(g_fit, g_gauss)
+
+
+def test_metacal_psf_azgauss_is_a_live_alternative():
+    """``azgauss`` (ngmix >= 2.4.1) is the noise-robust ``gauss`` variant.
+
+    It must run to a finite shear and differ from ``fitgauss`` — this both wires
+    the knob through and asserts the bumped ngmix actually provides the kernel.
+    """
+    g_fit = _metacal_noshear_g_with_psf(42, metacal_psf="fitgauss")
+    g_az = _metacal_noshear_g_with_psf(42, metacal_psf="azgauss")
+    assert np.all(np.isfinite(g_az))
+    assert not np.array_equal(g_fit, g_az)
+
+
 # The two PSF families carry distinct ellipticity AND size (shapepipe#749):
 # the original image PSF (-> *_psf_orig) and the metacal reconvolution kernel
 # (-> *_psf_reconv) are independent fits, so a regression to the old aliasing

--- a/uv.lock
+++ b/uv.lock
@@ -2094,8 +2094,8 @@ wheels = [
 
 [[package]]
 name = "ngmix"
-version = "2.4.0"
-source = { git = "https://github.com/esheldon/ngmix?tag=v2.4.0#d08b471f4c4d5887df9f9f2551efaf8f2e226150" }
+version = "2.4.1"
+source = { git = "https://github.com/esheldon/ngmix?tag=v2.4.1#0b5c835ec020ed9253afea64886de53f4be3577a" }
 
 [[package]]
 name = "nh3"
@@ -3428,7 +3428,7 @@ requires-dist = [
     { name = "modopt", specifier = ">=1.6" },
     { name = "mpi4py", specifier = ">=4.1.2" },
     { name = "myst-parser", marker = "extra == 'doc'" },
-    { name = "ngmix", git = "https://github.com/esheldon/ngmix?tag=v2.4.0" },
+    { name = "ngmix", git = "https://github.com/esheldon/ngmix?tag=v2.4.1" },
     { name = "numba", specifier = ">=0.59" },
     { name = "numpy", specifier = ">=2.4.6" },
     { name = "numpydoc", marker = "extra == 'doc'" },


### PR DESCRIPTION
Exposes metacal's reconvolution-kernel scheme (`metacal_pars['psf']`) as an optional `METACAL_PSF` config knob and bumps the ngmix pin `v2.4.0 → v2.4.1`, which adds `azgauss` — a noise-robust variant of `gauss`. The knob is the mechanism #819 asks for: try `azgauss` against the fiducial `fitgauss` via digital-twin / image-sim m/c bias before flipping the default.

- **Options:** `fitgauss` (default), `gauss`, `dilate`, `azgauss`.
- **Byte-for-byte default:** the knob defaults to the old unconditional `fitgauss`; a test asserts bit-identical output to the pre-knob path.
- **Live-wire:** tests assert `gauss`/`azgauss` run to finite, distinct shears (the latter also confirms the bumped ngmix provides the kernel).

The reconvolution kernel is a separate object from the PSF-model fit: it sets the round PSF metacal reconvolves with after shearing, so it moves the metacal response (and recovered shear) but never reaches the deconvolution. Mirrors the additive `CENTROID_SOURCE` pattern.

Closes #819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude (Opus) on behalf of Cail