### PR TITLE
chore(renovate): explicitly zero minimumReleaseAge to override Mend org layer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,11 @@
   "description": [
     "Low-noise dependency updates; uv owns version resolution. pyproject keeps floor ranges and Renovate uses the org default rangeStrategy=update-lockfile, so `uv lock` picks versions jointly — cross-package conflicts (e.g. numba capping numpy) resolve silently instead of failing the batch, and un-stick themselves when upstream catches up. No minimumReleaseAge: it is unenforceable with uv resolution (renovatebot/renovate#41624 forced exact pins, which forced manual conflict caps); CI running the full suite in the container is the automerge gate.",
     "Noise: all non-major updates grouped into one weekly PR that automerges when CI is green; majors surface individually; lockFileMaintenance refreshes transitive deps weekly.",
-    "python is guarded: Renovate classes base-image bumps like 3.12 -> 3.14 as 'minor', so it gets its own PR and never automerges — a Python upgrade gets human eyes without holding the weekly batch hostage."
+    "python is guarded: Renovate classes base-image bumps like 3.12 -> 3.14 as 'minor', so it gets its own PR and never automerges — a Python upgrade gets human eyes without holding the weekly batch hostage.",
+    "minimumReleaseAge is EXPLICITLY zeroed, not merely absent: Mend's hosted org layer injects an age gate invisibly, and merely deleting the key here does not override inherited config — artifact updates then fail on every uv-resolved transitive that is younger than the invisible gate (see #816). An explicit '0 days' should win the merge over the inherited value; if artifact errors persist, the gate lives in Mend portal-global settings and must be removed at developer.mend.io."
   ],
   "extends": ["config:recommended", "group:allNonMajor", "schedule:weekly"],
+  "minimumReleaseAge": "0 days",
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     { "matchUpdateTypes": ["minor", "patch", "pin", "digest"], "automerge": true },


### PR DESCRIPTION
## Why

Our `renovate.json` has had **no** `minimumReleaseAge` since #822, yet #816 still fails artifact updates with *"has not yet passed the Minimum Release Age threshold"* (tqdm 4.68.4, hypothesis 6.156.6). The gate is therefore injected by **Mend's hosted org-level config** — and an *absent* key in repo config does not override an *inherited* one.

## What

One line: `"minimumReleaseAge": "0 days"` at top level, so the repo value explicitly wins the config merge. Plus a description entry documenting the reasoning.

## Diagnostic either way

- If the next renovate run produces green artifacts → done, the invisible gate is beaten.
- If the error persists → proof the gate lives in Mend **portal-global** settings (unreachable from any repo config), and the fix moves to developer.mend.io (or self-hosting Renovate via Actions).

Upstream context: renovatebot/renovate#41624 (age gate fundamentally incompatible with uv-owned resolution) — still open, no movement since March.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZvom4Uzdoz5KbJeG8yhde