### PR TITLE
chore: automerge Renovate lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "rangeStrategy": "update-lockfile",
-  "lockFileMaintenance": { "enabled": true },
+  "lockFileMaintenance": { "enabled": true, "automerge": true },
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": { "automerge": true, "labels": ["security"] },
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "THE ONLY Renovate config file — do not add another. A forgotten .github/renovate.json5 (the original Dependabot->Renovate migration config) shadowed this file for weeks: Renovate's config discovery (and Mend's cached config-file name) preferred it, so edits here were silently ignored while its 14-day minimumReleaseAge broke every uv artifact update (renovatebot/renovate#41624). Deleted 2026-07; if Renovate ever again behaves contrary to this file, first check for a second config file (renovate.json5, .github/renovate.json*, .renovaterc*), then the Mend portal's resolved config.",
     "Low-noise dependency updates; uv owns version resolution. pyproject keeps floor ranges and rangeStrategy=update-lockfile means `uv lock` picks versions jointly — cross-package conflicts (e.g. numba capping numpy) resolve silently instead of failing the batch, and un-stick themselves when upstream catches up. No minimumReleaseAge anywhere: any age gate is unenforceable with uv resolution (#41624 — uv resolves transitives past the gate and the artifact step fails); CI running the full suite in the container is the automerge gate.",
     "Noise: all non-major updates grouped into one weekly PR that automerges when CI is green; majors are gated behind an explicit dashboard-approval tick; lockFileMaintenance refreshes transitive deps weekly. Security fixes (GitHub + OSV alerts) automerge on green CI without waiting for the weekly schedule.",
-    "python is guarded: Renovate classes base-image bumps like 3.12 -> 3.14 as 'minor', so it gets its own PR and never automerges — a Python upgrade gets human eyes without holding the weekly batch hostage. ngmix is pinned to a tag in [tool.uv.sources] as a deliberate shape-measurement decision — Renovate must not touch it."
+    "python is guarded: Renovate classes base-image bumps like 3.12 -> 3.14 as 'minor', so the major-only approval rule wouldn't catch it — its own packageRule adds dependencyDashboardApproval so a bump sits as an unchecked dashboard item instead of an immortal PR, until someone deliberately ticks it. ngmix is pinned to a tag in [tool.uv.sources] as a deliberate shape-measurement decision — Renovate must not touch it."
   ],
   "extends": [
     "config:recommended",
@@ -19,7 +19,7 @@
   "packageRules": [
     { "matchUpdateTypes": ["minor", "patch", "pin", "digest"], "automerge": true },
     { "matchUpdateTypes": ["major"], "dependencyDashboardApproval": true },
-    { "matchPackageNames": ["python"], "groupName": "python", "automerge": false },
+    { "matchPackageNames": ["python"], "groupName": "python", "automerge": false, "dependencyDashboardApproval": true },
     { "matchDepNames": ["ngmix"], "enabled": false }
   ]
 }


### PR DESCRIPTION
lockFileMaintenance is its own Renovate update type, not covered by the minor/patch/pin/digest automerge rule, so the weekly lock-refresh PR sat unmerged since July while Dependabot alerts piled up. This adds `automerge: true` to `lockFileMaintenance` so it merges on green CI like the rest.

Also gates python version bumps behind dashboard approval: Renovate classes base-image bumps like 3.12→3.14 as "minor" rather than "major", so they weren't caught by the major-only approval rule and instead produced an immortal, perpetually-open PR (#866). We're staying on 3.12 deliberately; a python bump now needs an explicit dashboard tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)