### PR TITLE
fix(psf): deterministic star train/validation split; align tile STAR_THRESH with the 80% convention

### DIFF
--- a/example/cfis/config_tile_PiViVi_canfar_sx.ini
+++ b/example/cfis/config_tile_PiViVi_canfar_sx.ini
@@ -79,7 +79,7 @@ POSITION_PARAMS = XWIN_WORLD,YWIN_WORLD
 GET_SHAPES = True
 
 # Number of stars threshold
-STAR_THRESH = 20
+STAR_THRESH = 22
 
 # chi^2 threshold
 CHI2_THRESH = 2

--- a/example/cfis/config_tile_PiViVi_canfar_uc.ini
+++ b/example/cfis/config_tile_PiViVi_canfar_uc.ini
@@ -77,7 +77,7 @@ POSITION_PARAMS = XWIN_WORLD,YWIN_WORLD
 GET_SHAPES = True
 
 # Number of stars threshold
-STAR_THRESH = 20
+STAR_THRESH = 22
 
 # chi^2 threshold
 CHI2_THRESH = 2

--- a/src/shapepipe/modules/setools_package/setools.py
+++ b/src/shapepipe/modules/setools_package/setools.py
@@ -658,13 +658,18 @@ class SETools(object):
 
             cat_size = len(np.where(mask)[0])
             n_keep = int(np.ceil(cat_size * ratio))
-            mask_ratio = []
-            mask_left = list(range(0, cat_size))
-            while len(mask_ratio) != n_keep:
-                idx = np.random.randint(0, len(mask_left))
-                mask_ratio.append(mask_left.pop(idx))
-            mask_ratio = np.array(mask_ratio)
-            mask_left = np.array(mask_left)
+            # Deterministic split, seeded from the unit's file number: the
+            # train/validation assignment is a pure function of the input
+            # catalogue, so the PSF star sample (and everything downstream
+            # of the PSF model) is reproducible run-to-run. An unseeded
+            # np.random here made the shear catalogue non-reproducible
+            # upstream of ngmix's own position seeding.
+            seed = int(
+                re.sub(r"\D", "", self._file_number_string) or 0
+            ) % (2 ** 32)
+            perm = np.random.RandomState(seed).permutation(cat_size)
+            mask_ratio = perm[:n_keep]
+            mask_left = np.sort(perm[n_keep:])
             self.rand_split[key]["mask"] = mask
             self.rand_split[key][f"ratio_{int(ratio * 100)}"] = mask_ratio
             self.rand_split[key][f"ratio_{100 - int(ratio * 100)}"] = mask_left


### PR DESCRIPTION
Two small fixes to how the PSF star sample is built, found while auditing the scientific decisions embedded in the pipeline configs.

**1. Seed the train/validation split.** `SETools._make_rand_split` drew the 80/20 star split from unseeded `np.random`, so the star sample entering the PSF model — and everything downstream of it — differed between identical runs. The split is now a permutation seeded from the unit's file number: deterministic per CCD, independent of processing order, same philosophy as ngmix's `SEED_FROM_POSITION`. (This changes the realized split once — equivalent to one more random draw, now frozen.)

**2. STAR_THRESH 20 → 22 in the tile PSF-interp configs.** fdc86553 (2020) deliberately raised the per-CCD acceptance threshold to 22 to account for the 80% training split, but only in `config_exp_psfex.ini` (the validation pass). The tile configs that feed galaxies kept the stale 20, so the science path admits CCDs under the pre-split standard while validation gates at 22. We think the right fix is to align on 22.

Both change outputs slightly (a new frozen split; CCDs with 20–21 accepted stars now excluded, matching validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jrs8TeTCccRMC45QVGKPeY